### PR TITLE
Added support for ByteArrayColumnType, fixes #23

### DIFF
--- a/sqlest/src/main/scala/sqlest/ast/Column.scala
+++ b/sqlest/src/main/scala/sqlest/ast/Column.scala
@@ -101,6 +101,7 @@ sealed trait AliasedColumn[A] extends Column[A] with CellExtractor[ResultSet, A]
       case BooleanColumnType => checkNull(resultSet.getBoolean(columnAlias))
       case StringColumnType => checkNull(resultSet.getString(columnAlias))
       case DateTimeColumnType => checkNull(new DateTime(resultSet.getDate(columnAlias)))
+      case ByteArrayColumnType => checkNull(resultSet.getBytes(columnAlias))
     }
   }
 

--- a/sqlest/src/main/scala/sqlest/ast/ColumnType.scala
+++ b/sqlest/src/main/scala/sqlest/ast/ColumnType.scala
@@ -51,6 +51,7 @@ case object BigDecimalColumnType extends NumericColumnType[BigDecimal]
 case object BooleanColumnType extends NonNumericColumnType[Boolean]
 case object StringColumnType extends NonNumericColumnType[String]
 case object DateTimeColumnType extends NonNumericColumnType[DateTime]
+case object ByteArrayColumnType extends NonNumericColumnType[Array[Byte]]
 
 /**
  * Class representing an nullable SQL column type that is mapped to an `Option` in Scala.
@@ -119,6 +120,7 @@ object ColumnType {
   implicit val bigDecimalColumnType = BigDecimalColumnType
   implicit val stringColumnType = StringColumnType
   implicit val dateTimeColumnType = DateTimeColumnType
+  implicit val byteArrayColumnType = ByteArrayColumnType
   implicit def apply[A, B]: MappedColumnType[A, B] = macro MaterializeColumnTypeMacro.materializeImpl[A, B]
 
   implicit def optionType[A, B](implicit base: ColumnType.Aux[A, B]) = OptionColumnType[A, B](base)

--- a/sqlest/src/main/scala/sqlest/ast/syntax/UntypedColumnSyntax.scala
+++ b/sqlest/src/main/scala/sqlest/ast/syntax/UntypedColumnSyntax.scala
@@ -35,6 +35,7 @@ class UntypedColumnHelpers extends ColumnSyntax {
   }
   def bigDecimalArgument(arg: String) = Try(BigDecimal(arg)).toOption
   def dateTimeArgument(arg: String) = Iso8601.unapply(arg)
+  def byteArrayArgument(arg: String) = Try(javax.xml.bind.DatatypeConverter.parseHexBinary(arg)).toOption
   def mappedArgument[A](arg: String, columnType: ColumnType[A]): Option[A] = (columnType match {
     case IntColumnType => intArgument(arg)
     case LongColumnType => longArgument(arg)
@@ -43,6 +44,7 @@ class UntypedColumnHelpers extends ColumnSyntax {
     case BooleanColumnType => booleanArgument(arg)
     case StringColumnType => stringArgument(arg)
     case DateTimeColumnType => dateTimeArgument(arg)
+    case ByteArrayColumnType => byteArrayArgument(arg)
     case _ => sys.error(s"Untyped operators are not implemented for non-standard mapped types: $columnType")
   }).asInstanceOf[Option[A]]
 
@@ -54,6 +56,7 @@ class UntypedColumnHelpers extends ColumnSyntax {
     case BooleanColumnType => booleanArgument(right).map(right => InfixFunctionColumn[Boolean](op, left, right))
     case StringColumnType => stringArgument(right).map(right => InfixFunctionColumn[Boolean](op, left, right))
     case DateTimeColumnType => dateTimeArgument(right).map(right => InfixFunctionColumn[Boolean](op, left, right))
+    case ByteArrayColumnType => byteArrayArgument(right).map(right => InfixFunctionColumn[Boolean](op, left, right))
     case optionColumnType: OptionColumnType[_, _] => infixExpression(op, left, right, optionColumnType.baseColumnType)
     case mappedColumnType: MappedColumnType[_, _] =>
       mappedArgument(right, mappedColumnType).map { right =>

--- a/sqlest/src/main/scala/sqlest/sql/DB2StatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/DB2StatementBuilder.scala
@@ -50,6 +50,7 @@ trait DB2StatementBuilder extends base.StatementBuilder {
       case DoubleColumnType => "double"
       case IntColumnType => "integer"
       case LongColumnType => "bigint"
+      case ByteArrayColumnType => "varbinary(32704)"
       case optionColumnType: OptionColumnType[_, _] => castLiteralSql(optionColumnType.baseColumnType)
       case mappedColumnType: MappedColumnType[_, _] => castLiteralSql(mappedColumnType.baseColumnType)
     }

--- a/sqlest/src/main/scala/sqlest/sql/base/BaseStatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/BaseStatementBuilder.scala
@@ -154,6 +154,7 @@ trait BaseStatementBuilder {
     case BigDecimalColumnType => value.toString
     case StringColumnType => "'" + escapeSqlString(value.toString) + "'"
     case DateTimeColumnType => value.toString
+    case ByteArrayColumnType => javax.xml.bind.DatatypeConverter.printHexBinary(value.asInstanceOf[Array[Byte]])
     case optionType: OptionColumnType[_, _] =>
       val option = value.asInstanceOf[Option[_]]
       if (option.isEmpty) "null" else constantSql(optionType.baseColumnType.asInstanceOf[ColumnType[Any]], option.get)

--- a/sqlest/src/main/scala/sqlest/sql/base/StatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/StatementBuilder.scala
@@ -105,6 +105,7 @@ trait StatementBuilder extends BaseStatementBuilder
     case DoubleColumnType => statement.setDouble(index, value.asInstanceOf[Double])
     case BigDecimalColumnType => statement.setBigDecimal(index, value.asInstanceOf[BigDecimal].bigDecimal)
     case StringColumnType => statement.setString(index, value.asInstanceOf[String])
+    case ByteArrayColumnType => statement.setBytes(index, value.asInstanceOf[Array[Byte]])
     case DateTimeColumnType => statement.setTimestamp(index, new JdbcTimestamp(value.asInstanceOf[DateTime].getMillis))
     case optionType: OptionColumnType[_, _] =>
       val option = value.asInstanceOf[Option[_]]
@@ -119,6 +120,7 @@ trait StatementBuilder extends BaseStatementBuilder
     case DoubleColumnType => JdbcTypes.DOUBLE
     case BigDecimalColumnType => JdbcTypes.DECIMAL
     case StringColumnType => JdbcTypes.CHAR
+    case ByteArrayColumnType => JdbcTypes.BINARY
     case DateTimeColumnType => JdbcTypes.TIMESTAMP
     case optionType: OptionColumnType[_, _] => jdbcType(optionType.baseColumnType)
     case mappedType: MappedColumnType[_, _] => jdbcType(mappedType.baseColumnType)


### PR DESCRIPTION
So here's my first stab at adding support for binary columns. Please review and comment. 

I tried to cover all the parts, including the `DB2StatementBuilder`, which I set the type to `binary(32704)` because of [this](http://www-01.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/com.ibm.db2z10.doc.intro/src/tpc/db2z_stringdatatypes.dita?lang=en).

As for string representation of `byte[]`, I use JVMs `javax.xml.bind.DatatypeConverter` to encode/decore to Hex strings.
