### PR TITLE
Make SeqExtractor varargs.

### DIFF
--- a/extractors/src/main/scala/sqlest/extractor/CaseClassExtractorMacro.scala
+++ b/extractors/src/main/scala/sqlest/extractor/CaseClassExtractorMacro.scala
@@ -163,7 +163,7 @@ case class CaseClassExtractorMacro(c: Context) {
     val treeNames = paramNames.map(name => q"$name")
     if (applyMethod.isVarargs) {
       val varargsBaseType = paramTypes.last match { case TypeRef(_, _, typ :: Nil) => typ }
-      treeNames.init :+ q"sqlest.extractor.SeqExtractor[$typeOfRow, $varargsBaseType](${paramNames.last}.toSeq)"
+      treeNames.init :+ q"sqlest.extractor.SeqExtractor[$typeOfRow, $varargsBaseType](${paramNames.last}.toSeq: _*)"
     } else treeNames
   }
 

--- a/extractors/src/main/scala/sqlest/extractor/Extractor.scala
+++ b/extractors/src/main/scala/sqlest/extractor/Extractor.scala
@@ -134,7 +134,7 @@ case class MappedExtractor[Row, A, B](inner: Extractor[Row, A], func: A => B) ex
 /**
  * An extractor that aggregates results from a seq of extractors into a seq.
  */
-case class SeqExtractor[Row, A](extractors: Seq[Extractor[Row, A]]) extends Extractor[Row, Seq[A]] with SimpleExtractor[Row, Seq[A]] with SingleRowExtractor[Row, Seq[A]] {
+case class SeqExtractor[Row, A](extractors: Extractor[Row, A]*) extends Extractor[Row, Seq[A]] with SimpleExtractor[Row, Seq[A]] with SingleRowExtractor[Row, Seq[A]] {
   type Accumulator = Seq[Any]
 
   def initialize(row: Row): Accumulator = extractors.map(_.initialize(row))

--- a/extractors/src/main/scala/sqlest/extractor/ExtractorFinder.scala
+++ b/extractors/src/main/scala/sqlest/extractor/ExtractorFinder.scala
@@ -48,7 +48,7 @@ object ExtractorFinder {
           case _ => None
         }
 
-      case SeqExtractor(extractors) =>
+      case SeqExtractor(extractors @ _*) =>
         path match {
           case StringToInt(index) :: tail => apply(extractors(index), tail)
           case _ => None

--- a/extractors/src/test/scala/sqlest/extractor/ExtractorSpec.scala
+++ b/extractors/src/test/scala/sqlest/extractor/ExtractorSpec.scala
@@ -165,9 +165,11 @@ class ExtractorSpec extends FlatSpec with Matchers with ExtractorSyntax[Seq[Any]
     val seqRows = List(Seq(0, 1, 2), Seq(2, 3, 4), Seq(5, 6, 7))
     val seqExtractor: SeqExtractor[Seq[Any], Int] =
       SeqExtractor(
-        intExtractorAtIndex(0),
-        intExtractorAtIndex(1),
-        intExtractorAtIndex(2).map(_ * 2)
+        Seq(
+          intExtractorAtIndex(0),
+          intExtractorAtIndex(1),
+          intExtractorAtIndex(2).map(_ * 2)
+        ): _*
       )
 
     seqExtractor.extractHeadOption(Nil) should be(None)

--- a/extractors/src/test/scala/sqlest/extractor/ExtractorSpec.scala
+++ b/extractors/src/test/scala/sqlest/extractor/ExtractorSpec.scala
@@ -164,10 +164,11 @@ class ExtractorSpec extends FlatSpec with Matchers with ExtractorSyntax[Seq[Any]
   "SeqExtractor" should "extract values from all extractors and return them in a Seq" in {
     val seqRows = List(Seq(0, 1, 2), Seq(2, 3, 4), Seq(5, 6, 7))
     val seqExtractor: SeqExtractor[Seq[Any], Int] =
-      SeqExtractor(Seq(
+      SeqExtractor(
         intExtractorAtIndex(0),
         intExtractorAtIndex(1),
-        intExtractorAtIndex(2).map(_ * 2)))
+        intExtractorAtIndex(2).map(_ * 2)
+      )
 
     seqExtractor.extractHeadOption(Nil) should be(None)
     seqExtractor.extractHeadOption(seqRows) should be(Some(Seq(0, 1, 4)))
@@ -181,10 +182,11 @@ class ExtractorSpec extends FlatSpec with Matchers with ExtractorSyntax[Seq[Any]
   it should "throw a NullPointerException if any of the inner extractors extracted a null value" in {
     val seqRows = List(Seq(null, 1, 2), Seq(2, 3, 4), Seq(5, 6, null))
     val seqExtractor: SeqExtractor[Seq[Any], Int] =
-      SeqExtractor(Seq(
+      SeqExtractor(
         intExtractorAtIndex(0),
         intExtractorAtIndex(1),
-        intExtractorAtIndex(2).map(_ * 2)))
+        intExtractorAtIndex(2).map(_ * 2)
+      )
 
     intercept[NullPointerException] {
       seqExtractor.extractHeadOption(seqRows)
@@ -245,11 +247,11 @@ class ExtractorSpec extends FlatSpec with Matchers with ExtractorSyntax[Seq[Any]
   it should "wrap a SeqExtractor and wrap any null value in an Option" in {
     val seqRows = List(Seq(null, 1, 2), Seq(2, 3, 4), Seq(5, 6, null))
     val seqExtractor: OptionExtractor[Seq[Any], Seq[Int]] =
-      SeqExtractor(Seq(
+      SeqExtractor(
         intExtractorAtIndex(0),
         intExtractorAtIndex(1),
         intExtractorAtIndex(2).map(_ * 2)
-      )).asOption
+      ).asOption
 
     seqExtractor.extractHeadOption(Nil) should be(None)
     seqExtractor.extractHeadOption(seqRows) should be(Some(None))

--- a/sqlest/src/main/scala/sqlest/extractor/ColumnExtractorSyntax.scala
+++ b/sqlest/src/main/scala/sqlest/extractor/ColumnExtractorSyntax.scala
@@ -35,7 +35,7 @@ trait ColumnExtractorSyntax {
         case productExtractor: ProductExtractor[_, _] => productExtractor.innerExtractors.flatMap(_.columns)
         case MappedExtractor(innerExtractor, _) => innerExtractor.columns
         case OptionExtractor(innerExtractor) => innerExtractor.columns
-        case SeqExtractor(extractors) => extractors.flatMap(_.columns).toList
+        case SeqExtractor(extractors @ _*) => extractors.flatMap(_.columns).toList
         case ListMultiRowExtractor(innerExtractor) => innerExtractor.columns
         case GroupedExtractor(innerExtractor, groupByExtractor) => innerExtractor.columns ++ groupByExtractor.columns
       }


### PR DESCRIPTION
This makes SeqExtractor slightly easier to use in most cases, but still allows
```scala
SeqExtractor(Seq(...): _*)
```