### PR TITLE
Easier composability / syntax for MappedColumnType

### DIFF
--- a/sqlest/src/main/scala/sqlest/ast/ColumnType.scala
+++ b/sqlest/src/main/scala/sqlest/ast/ColumnType.scala
@@ -96,15 +96,33 @@ object MappedColumnType {
    * Convenience method for constructing a `MappedColumnType` from a pair of
    * bidirectional mapping functions and an implicitly provided `BaseColumnType`.
    */
-  def apply[A, B: BaseColumnType](r: Option[B] => Option[A], w: A => B)(implicit innerColumnType: ColumnType.Aux[B, B]) = new MappedColumnType[A, B] {
+  def apply[A, B: BaseColumnType](r: B => A, w: A => B)(implicit innerColumnType: ColumnType.Aux[B, B]) = new MappedColumnType[A, B] {
     val baseColumnType = implicitly[BaseColumnType[B]]
-    def read(database: Option[Database]) = r(innerColumnType.read(database))
+    def read(database: Option[Database]) = r.lift(innerColumnType.read(database))
     def write(value: A) = innerColumnType.write(w(value))
   }
 
-  implicit class MappedColumnTypeOps[A, B](mappedColumnType: MappedColumnType[A, B]) {
-    def compose[C: BaseColumnType](inner: ColumnType.Aux[B, C]): MappedColumnType[A, C] = {
-      MappedColumnType((database: Option[C]) => mappedColumnType.read(inner.read(database)), (value: A) => inner.write(mappedColumnType.write(value)))
+  implicit class MappedColumnTypeOps[B, C: BaseColumnType](baseColumnType: ColumnType.Aux[B, C]) {
+    def compose[A](outerColumnType: ColumnType.Aux[A, B]): MappedColumnType[A, C] = {
+      val baseRead = (baseColumnType.read _).unlift
+      val mappedRead = (outerColumnType.read _).unlift
+      MappedColumnType(
+        (database: C) => mappedRead(baseRead(database)),
+        (value: A) => baseColumnType.write(outerColumnType.write(value))
+      )
+    }
+  }
+
+  implicit class LiftableOps[A, B](func: A => B) {
+    def lift: Option[A] => Option[B] = {
+      case Some(a) => Some(func(a))
+      case _ => None
+    }
+  }
+
+  implicit class UnliftableOps[A, B](func: Option[A] => Option[B]) {
+    def unlift: A => B = {
+      case a => func(Some(a)).get
     }
   }
 }
@@ -142,7 +160,7 @@ case class MaterializeColumnTypeMacro(c: Context) {
     val applyMethod = findMethod(companion.typeSignature, "apply", typeOfA)
     val unapplyMethod = findMethod(companion.typeSignature, "unapply", typeOfA)
     val typeOfB = applyMethod.paramLists.head.head.asTerm.typeSignature
-    q"MappedColumnType[$typeOfA, $typeOfB](_.map($companion.$applyMethod), $companion.$unapplyMethod(_).get)"
+    q"MappedColumnType[$typeOfA, $typeOfB]($companion.$applyMethod, $companion.$unapplyMethod(_).get)"
   }
 
   def findMethod(companionType: Type, name: String, typeOfA: Type) = {

--- a/sqlest/src/main/scala/sqlest/ast/ColumnType.scala
+++ b/sqlest/src/main/scala/sqlest/ast/ColumnType.scala
@@ -101,31 +101,16 @@ object MappedColumnType {
    */
   def apply[A, B: BaseColumnType](r: B => A, w: A => B)(implicit innerColumnType: ColumnType.Aux[B, B]) = new MappedColumnType[A, B] {
     val baseColumnType = implicitly[BaseColumnType[B]]
-    def read(database: Option[Database]) = r.lift(innerColumnType.read(database))
+    def read(database: Option[Database]) = innerColumnType.read(database).map(r)
     def write(value: A) = innerColumnType.write(w(value))
   }
 
   implicit class MappedColumnTypeOps[B, C: BaseColumnType](baseColumnType: ColumnType.Aux[B, C]) {
     def compose[A](outerColumnType: ColumnType.Aux[A, B]): MappedColumnType[A, C] = {
-      val baseRead = (baseColumnType.read _).unlift
-      val mappedRead = (outerColumnType.read _).unlift
       MappedColumnType(
-        (database: C) => mappedRead(baseRead(database)),
+        (database: C) => outerColumnType.read(baseColumnType.read(Some(database))).get,
         (value: A) => baseColumnType.write(outerColumnType.write(value))
       )
-    }
-  }
-
-  implicit class LiftableOps[A, B](func: A => B) {
-    def lift: Option[A] => Option[B] = {
-      case Some(a) => Some(func(a))
-      case _ => None
-    }
-  }
-
-  implicit class UnliftableOps[A, B](func: Option[A] => Option[B]) {
-    def unlift: A => B = {
-      case a => func(Some(a)).get
     }
   }
 }

--- a/sqlest/src/test/scala/sqlest/ast/ColumnSpec.scala
+++ b/sqlest/src/test/scala/sqlest/ast/ColumnSpec.scala
@@ -39,7 +39,7 @@ class ColumnSpec extends FlatSpec with Matchers {
   class TableOne(alias: Option[String]) extends Table("one", alias) {
     val col1 = column[Int]("col1")
     val col2 = column[String]("col2")
-    val col3 = column[Int]("col3")(MappedColumnType[Int, String](_.map(_.toInt), _.toString))
+    val col3 = column[Int]("col3")(MappedColumnType[Int, String](_.toInt, _.toString))
     val col4 = column[Double]("col1")
     val col5 = column[Option[String]]("col5")(OptionColumnType(""))
     val col6 = column[Size]("col6")

--- a/sqlest/src/test/scala/sqlest/untyped/ast/ColumnSpec.scala
+++ b/sqlest/src/test/scala/sqlest/untyped/ast/ColumnSpec.scala
@@ -31,7 +31,7 @@ class ColumnSpec extends FlatSpec with Matchers {
     val booleanCol = column[Boolean]("Col")
     val stringCol = column[String]("Col")
     val dateTimeCol = column[DateTime]("Col")
-    val mappedCol = column[Int]("Col")(MappedColumnType[Int, String](_.map(_.toInt), _.toString))
+    val mappedCol = column[Int]("Col")(MappedColumnType[Int, String](_.toInt, _.toString))
   }
 
   object TableOne extends TableOne(None)


### PR DESCRIPTION
More intuitive composability of MappedColumnType, and lifts the bidirectional mapping function the user supplies on MappedColumnType's apply method to an Option type so they don't have to do this.