### PR TITLE
correct library string location for sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ resolvers ++= Seq(
 and the following library dependency
 ```scala
 libraryDependencies ++= Seq(
-  "co.uk.jhc" %% "sqlest" % "0.6.3"
+  "uk.co.jhc" %% "sqlest" % "0.6.3"
 )
 ```
 


### PR DESCRIPTION
Changed the path for the JHC repo used by sbt