### PR TITLE
Add `andWhere` to make the possibility of chaining `where` more obvious

### DIFF
--- a/sqlest/src/main/scala/sqlest/ast/Relation.scala
+++ b/sqlest/src/main/scala/sqlest/ast/Relation.scala
@@ -150,6 +150,11 @@ case class Select[A, R <: Relation](
   def where(expr: Column[Boolean]): Select[A, R] =
     this.copy(where = this.where map (_ && expr) orElse Some(expr))
 
+  def andWhere(expr: Column[Boolean]): Select[A, R] = where(expr)
+
+  def orWhere(expr: Column[Boolean]): Select[A, R] =
+    this.copy(where = this.where map (_ || expr) orElse Some(expr))
+
   def startWith(expr: Column[Boolean]): Select[A, R] =
     this.copy(startWith = this.startWith map (_ && expr) orElse Some(expr))
 
@@ -161,6 +166,11 @@ case class Select[A, R <: Relation](
 
   def having(expr: Column[Boolean]): Select[A, R] =
     this.copy(having = this.having map (_ && expr) orElse Some(expr))
+
+  def andHaving(expr: Column[Boolean]): Select[A, R] = having(expr)
+
+  def orHaving(expr: Column[Boolean]): Select[A, R] =
+    this.copy(having = this.having map (_ || expr) orElse Some(expr))
 
   def orderBy(orders: Order*): Select[A, R] =
     this.copy(orderBy = this.orderBy ++ orders)

--- a/sqlest/src/test/scala/sqlest/ast/SelectSpec.scala
+++ b/sqlest/src/test/scala/sqlest/ast/SelectSpec.scala
@@ -54,6 +54,16 @@ class SelectSpec extends FlatSpec with Matchers {
     query.where should equal(Some(MyTable.col1 > 1 && MyTable.col1 < 2))
   }
 
+  "andWhere" should "append new filters" in {
+    val query = select.from(MyTable).where(MyTable.col1 > 1).andWhere(MyTable.col1 < 2)
+    query.where should equal(Some(MyTable.col1 > 1 && MyTable.col1 < 2))
+  }
+
+  "orWhere" should "append new filters" in {
+    val query = select.from(MyTable).where(MyTable.col1 > 1).orWhere(MyTable.col1 < 2)
+    query.where should equal(Some(MyTable.col1 > 1 || MyTable.col1 < 2))
+  }
+
   "repeated calls to select.orderBy()" should "append new orders" in {
     val query = select.from(MyTable).orderBy(MyTable.col1).orderBy(MyTable.col2.desc)
     query.orderBy should equal(List(Order(MyTable.col1, true), Order(MyTable.col2, false)))


### PR DESCRIPTION
Several users have asked me how to chain `where` clauses without mapping over `select.where`.
I suggest we add `andWhere` to make the possibility of chaining `where` more obvious. Also `orWhere` and corresponding functions on `having`.