### PR TITLE
Fixing #44 - allow an OptionColumnType's nullValue to be used in where clauses

### DIFF
--- a/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
+++ b/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
@@ -44,10 +44,15 @@ class ExecutorSpec extends FlatSpec with Matchers {
       .columns(TableSix.trimmedString)
       .values(Setter(TableSix.trimmedString, LiteralColumn(None: Option[WrappedString])))
   }
-  val mappedOptionSelectStatement = {
+  val mappedOptionSelectStatement1 = {
     select(TableSix.zeroIsNoneLocalDate)
       .from(TableSix)
       .where(TableSix.zeroIsNoneLocalDate === Option.empty[LocalDate])
+  }
+  val mappedOptionSelectStatement2 = {
+    select(TableSix.zeroIsNoneLocalDate)
+      .from(TableSix)
+      .where(TableSix.zeroIsNoneLocalDate === Some(new LocalDate(2015, 1, 1)))
   }
   val deleteStatement = delete.from(TableOne).where(TableOne.col2 === "12")
 
@@ -202,8 +207,12 @@ class ExecutorSpec extends FlatSpec with Matchers {
       "insert into six (trimmedString) values ('')"
     )
 
-    testDatabase.statementBuilder.generateRawSql(mappedOptionSelectStatement) should equal(
+    testDatabase.statementBuilder.generateRawSql(mappedOptionSelectStatement1) should equal(
       "select six.zeroIsNoneDateTime as six_zeroIsNoneDateTime from six where (six.zeroIsNoneDateTime = 0)"
+    )
+
+    testDatabase.statementBuilder.generateRawSql(mappedOptionSelectStatement2) should equal(
+      "select six.zeroIsNoneDateTime as six_zeroIsNoneDateTime from six where (six.zeroIsNoneDateTime = 20150101)"
     )
   }
 

--- a/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
+++ b/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
@@ -16,6 +16,7 @@
 
 package sqlest.executor
 
+import org.joda.time.LocalDate
 import org.scalatest._
 import org.scalatest.matchers._
 import sqlest._
@@ -42,6 +43,11 @@ class ExecutorSpec extends FlatSpec with Matchers {
       .into(TableSix)
       .columns(TableSix.trimmedString)
       .values(Setter(TableSix.trimmedString, LiteralColumn(None: Option[WrappedString])))
+  }
+  val mappedOptionSelectStatement = {
+    select(TableSix.zeroIsNoneLocalDate)
+      .from(TableSix)
+      .where(TableSix.zeroIsNoneLocalDate === Option.empty[LocalDate])
   }
   val deleteStatement = delete.from(TableOne).where(TableOne.col2 === "12")
 
@@ -194,6 +200,10 @@ class ExecutorSpec extends FlatSpec with Matchers {
 
     testDatabase.statementBuilder.generateRawSql(mappedOptionInsertStatement2) should equal(
       "insert into six (trimmedString) values ('')"
+    )
+
+    testDatabase.statementBuilder.generateRawSql(mappedOptionSelectStatement) should equal(
+      "select six.zeroIsNoneDateTime as six_zeroIsNoneDateTime from six where (six.zeroIsNoneDateTime = 0)"
     )
   }
 


### PR DESCRIPTION
Allow an OptionColumnType's nullValue to be used in where clauses - this hopefully fixes #44.