### PR TITLE
Add DateTimeFromLocalDateColumnType

### DIFF
--- a/sqlest/src/main/scala/sqlest/ast/MappedColumnTypes.scala
+++ b/sqlest/src/main/scala/sqlest/ast/MappedColumnTypes.scala
@@ -135,6 +135,12 @@ trait LocalDateMappedColumnTypes {
     def read(database: Option[DateTime]) = database.map(_.toLocalDate)
     def write(value: LocalDate) = value.toDateTimeAtStartOfDay
   }
+
+  case object DateTimeFromLocalDateColumnType extends MappedColumnType[DateTime, LocalDate] {
+    val baseColumnType = LocalDateColumnType
+    def read(database: Option[LocalDate]) = database.map(_.toDateTimeAtStartOfDay)
+    def write(value: DateTime) = value.toLocalDate
+  }
 }
 
 trait OptionColumnTypes {

--- a/sqlest/src/test/scala/sqlest/TestData.scala
+++ b/sqlest/src/test/scala/sqlest/TestData.scala
@@ -73,7 +73,8 @@ object TestData {
     val zeroIsNoneWrappedInt = column[Option[WrappedInt]]("zeroIsNoneWrappedInt")(ZeroIsNoneColumnType[WrappedInt, Int])
     val zeroIsNoneLocalDate = column[Option[LocalDate]]("zeroIsNoneDateTime")(ZeroIsNoneColumnType(YyyyMmDdColumnType))
     val localDateFromDateTime = column[LocalDate]("localDateFromDateTime")(LocalDateFromDateTimeColumnType)
-    def columns = List(trimmedString, zeroIsNoneWrappedInt, zeroIsNoneLocalDate, localDateFromDateTime)
+    val dateTimeFromLocalDate = column[DateTime]("dateTimeFromLocalDate")(DateTimeFromLocalDateColumnType)
+    def columns = List(trimmedString, zeroIsNoneWrappedInt, zeroIsNoneLocalDate, localDateFromDateTime, dateTimeFromLocalDate)
   }
   object TableSix extends TableSix(None)
 

--- a/sqlest/src/test/scala/sqlest/extractor/ColumnExtractorSpec.scala
+++ b/sqlest/src/test/scala/sqlest/extractor/ColumnExtractorSpec.scala
@@ -54,24 +54,32 @@ class ColumnExtractorSpec extends FlatSpec with Matchers {
   }
 
   "mapped column extractor" should "extract mapped value" in {
-    val extractor = extractTuple(TableSix.trimmedString, TableSix.zeroIsNoneWrappedInt, TableSix.zeroIsNoneLocalDate, coalesce(TableSix.localDateFromDateTime).as(TableSix.localDateFromDateTime.columnAlias))
+    val extractor = extractTuple(
+      TableSix.trimmedString,
+      TableSix.zeroIsNoneWrappedInt,
+      TableSix.zeroIsNoneLocalDate,
+      coalesce(TableSix.localDateFromDateTime)
+        .as(TableSix.localDateFromDateTime.columnAlias),
+      coalesce(TableSix.dateTimeFromLocalDate)
+        .as(TableSix.dateTimeFromLocalDate.columnAlias)
+    )
 
     val timestamp = new java.sql.Timestamp(new java.util.Date().getTime)
     val date = new java.sql.Date(new java.util.Date().getTime)
     def testResultSet = TestResultSet(TableSix.columns)(
-      Seq("test", 5, 20150101, timestamp),
-      Seq(" test ", 0, 21000101, timestamp),
-      Seq("   ", 0, 0, timestamp)
+      Seq("test", 5, 20150101, timestamp, date),
+      Seq(" test ", 0, 21000101, timestamp, date),
+      Seq("   ", 0, 0, timestamp, date)
     )
 
     extractor.extractHeadOption(testResultSet) should equal(Some(
-      (Some(WrappedString("test")), Some(WrappedInt(5)), Some(new LocalDate(2015, 1, 1)), new LocalDate(date))
+      (Some(WrappedString("test")), Some(WrappedInt(5)), Some(new LocalDate(2015, 1, 1)), new LocalDate(date), new DateTime(date).withTimeAtStartOfDay)
     ))
 
     extractor.extractAll(testResultSet) should equal(List(
-      (Some(WrappedString("test")), Some(WrappedInt(5)), Some(new LocalDate(2015, 1, 1)), new LocalDate(date)),
-      (Some(WrappedString(" test")), None, Some(new LocalDate(2100, 1, 1)), new LocalDate(date)),
-      (None, None, None, new LocalDate(date))
+      (Some(WrappedString("test")), Some(WrappedInt(5)), Some(new LocalDate(2015, 1, 1)), new LocalDate(date), new DateTime(date).withTimeAtStartOfDay),
+      (Some(WrappedString(" test")), None, Some(new LocalDate(2100, 1, 1)), new LocalDate(date), new DateTime(date).withTimeAtStartOfDay),
+      (None, None, None, new LocalDate(date), new DateTime(date).withTimeAtStartOfDay)
     ))
   }
 


### PR DESCRIPTION
@brendanator, could you double-check my thinking here? This should allow round-tripping dates of the type constructed by a browser's date input control more easily while storing the date in the server's local timezone.

Set by a date picker in the browser:
```javascript
JSON.stringify(new Date("Wed Sep 30 2015 00:00:00 GMT+0100 (GMT Daylight Time)"))
=> "2015-09-29T23:00:00.000Z"
```

Writing to the database:
```scala
// Deserialization
scala> "2015-09-29T23:00:00.000Z" match { case Iso8601(date) => date }
res0: org.joda.time.DateTime = 2015-09-30T00:00:00.000+01:00

// DateTimeFromLocalDateColumnType.write
scala> res0.toLocalDate
res1: org.joda.time.LocalDate = 2015-09-30

// Session.setArgument
scala> res1.toDate.getTime
res2: Long = 1443567600000
```

Reading back out again:
```scala
// Column.readBaseType
scala> new LocalDate(res2)
res4: org.joda.time.LocalDate = 2015-09-30

// DateTimeFromLocalDateColumnType.read
scala> res4.toDateTimeAtStartOfDay
res5: org.joda.time.DateTime = 2015-09-30T00:00:00.000+01:00

// Serialization
scala> Iso8601(res5)
res6: String = 2015-09-29T23:00:00.000Z
```

Displaying in the browser:
```javascript
new Date("2015-09-29T23:00:00.000Z")
Wed Sep 30 2015 00:00:00 GMT+0100 (GMT Daylight Time)
```