### PR TITLE
Implement ChoiceExtractor

### DIFF
--- a/extractors/src/main/boilerplate/sqlest/extractor/ChoiceExtractorSyntax.scala.template
+++ b/extractors/src/main/boilerplate/sqlest/extractor/ChoiceExtractorSyntax.scala.template
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 JHC Systems Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sqlest.extractor
+
+trait ChoiceExtractorSyntax[Row, A] { self: Extractor[Row, A] =>
+[2..22#  def cond[[#B1 <: B#], B]([#choice1: (A => Boolean, Extractor[Row, B1])#]): Extractor[Row, B] = {
+    CondExtractor1(self, [#choice1#])
+  }#
+
+]
+
+[2..22#  def switch[[#B1 <: B#], B]([#choice1: (A, Extractor[Row, B1])#]): Extractor[Row, B] = {
+    SwitchExtractor1(self, [#choice1#])
+  }#
+
+]
+
+  def choose[B <: D, C <: D, D](pred: A => Boolean)(l: Extractor[Row, B], r: Extractor[Row, C]) =
+    CondExtractor2(self, (pred, l), ((a: A) => true, r))
+}

--- a/extractors/src/main/boilerplate/sqlest/extractor/CondExtractors.scala.template
+++ b/extractors/src/main/boilerplate/sqlest/extractor/CondExtractors.scala.template
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 JHC Systems Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sqlest.extractor
+
+[2..22#case class CondExtractor1[Row, A, [#B1 <: B#], B](inner: Extractor[Row, A], [#choice1: (A => Boolean, Extractor[Row, B1])#]) extends CondExtractor[Row, A, B] {
+  val extractors = List([#choice1._##2#])
+  val predicates = List([#choice1._##1#]).zipWithIndex
+}#
+
+]

--- a/extractors/src/main/boilerplate/sqlest/extractor/SwitchExtractors.scala.template
+++ b/extractors/src/main/boilerplate/sqlest/extractor/SwitchExtractors.scala.template
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 JHC Systems Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sqlest.extractor
+
+[2..22#case class SwitchExtractor1[Row, A, [#B1 <: B#], B](inner: Extractor[Row, A], [#choice1: (A, Extractor[Row, B1])#]) extends SwitchExtractor[Row, A, B] {
+  val extractors = List([#choice1._##2#])
+  val values = List([#choice1._##1#]).zipWithIndex
+}#
+
+]

--- a/extractors/src/main/scala/sqlest/extractor/Extractor.scala
+++ b/extractors/src/main/scala/sqlest/extractor/Extractor.scala
@@ -165,7 +165,7 @@ trait ChoiceExtractor[Row, A, B] extends Extractor[Row, B] with SimpleExtractor[
 }
 
 trait CondExtractor[Row, A, B] extends ChoiceExtractor[Row, A, B] {
-  protected val predicates: List[(A => Boolean, Int)]
+  val predicates: List[(A => Boolean, Int)]
 
   protected def selectExtractor[B1 <: B](row: Row, a: A): Extractor[Row, B1] = {
     predicates
@@ -176,7 +176,7 @@ trait CondExtractor[Row, A, B] extends ChoiceExtractor[Row, A, B] {
 }
 
 trait SwitchExtractor[Row, A, B] extends ChoiceExtractor[Row, A, B] {
-  protected val values: List[(A, Int)]
+  val values: List[(A, Int)]
 
   protected def selectExtractor[B1 <: B](row: Row, a: A): Extractor[Row, B1] = {
     values

--- a/extractors/src/main/scala/sqlest/extractor/ExtractorFinder.scala
+++ b/extractors/src/main/scala/sqlest/extractor/ExtractorFinder.scala
@@ -54,6 +54,12 @@ object ExtractorFinder {
           case _ => None
         }
 
+      case choice: ChoiceExtractor[_, _, _] =>
+        (choice.inner :: choice.extractors)
+          .map(apply(_, path))
+          .find(_.isDefined)
+          .flatten
+
       case MappedExtractor(inner, _, _) => apply(inner, path)
       case OptionExtractor(inner) => apply(inner, path)
       case NonOptionExtractor(inner) => apply(inner, path)

--- a/sqlest/src/main/scala/sqlest/extractor/ColumnExtractorSetters.scala
+++ b/sqlest/src/main/scala/sqlest/extractor/ColumnExtractorSetters.scala
@@ -65,22 +65,28 @@ trait ColumnExtractorSetters {
             case (extractor, value) => extractor.settersFor(value)
           }.toList
 
-        case choiceExtractor: ChoiceExtractor[ResultSet, a, b] =>
-          val setterLists = choiceExtractor.extractors.map {
-            case extractor: Extractor[ResultSet, c] =>
-              Try { extractor.settersFor(value.asInstanceOf[c]) }.toOption
+        case switchExtractor: SwitchExtractor[ResultSet, a, b] =>
+          val setterLists = switchExtractor.extractors.zipWithIndex.map {
+            case (extractor: Extractor[ResultSet, c], index) =>
+              Try { (extractor.settersFor(value.asInstanceOf[c]), index) }.toOption
           } collect {
-            case Some(setters) => setters
+            case Some((setters, index)) => (setters, index)
           }
+
+          val innerExtractor = switchExtractor.inner
+          val values = switchExtractor.values.map { case (value, index) => value }
 
           if (setterLists.length > 1) throw new Exception("Cannot use settersFor when there are ambiguous choices in a ChoiceExtractor")
           else if (setterLists.isEmpty) throw new Exception("Cannot use settersFor when there are no matching choices in a ChoiceExtractor")
-          else setterLists.head
+          else setterLists.head match {
+            case (setters, index) => (innerExtractor.settersFor(values(index)).toSet ++ setters).toList
+          }
 
         case ConstantExtractor(_) => Nil
         case _: MappedExtractor[ResultSet, _, _] => throw new Exception(s"Cannot use settersFor with a MappedExtractor without an unapplyMethod - $extractor")
         case _: ListMultiRowExtractor[ResultSet, _] => throw new Exception("Cannot use settersFor with a ListMultiRowExtractor")
         case _: GroupedExtractor[ResultSet, _, _] => throw new Exception("Cannot use settersFor with a GroupedExtractor")
+        case _: CondExtractor[ResultSet, _, _] => throw new Exception("Cannot use settersFor with a CondExtractor")
         case _ => throw new Exception(s"Cannot use settersFor with $extractor")
       }
     }

--- a/sqlest/src/main/scala/sqlest/extractor/ColumnExtractorSyntax.scala
+++ b/sqlest/src/main/scala/sqlest/extractor/ColumnExtractorSyntax.scala
@@ -33,6 +33,7 @@ trait ColumnExtractorSyntax {
         case column: AliasedColumn[_] => List(column)
         case _: CellExtractor[_, _] => Nil
         case productExtractor: ProductExtractor[_, _] => productExtractor.innerExtractors.flatMap(_.columns)
+        case choiceExtractor: ChoiceExtractor[_, _, _] => (choiceExtractor.inner :: choiceExtractor.extractors).flatMap(_.columns)
         case MappedExtractor(innerExtractor, _, _) => innerExtractor.columns
         case OptionExtractor(innerExtractor) => innerExtractor.columns
         case NonOptionExtractor(innerExtractor) => innerExtractor.columns

--- a/sqlest/src/test/scala/sqlest/extractor/ColumnExtractorSettersSpec.scala
+++ b/sqlest/src/test/scala/sqlest/extractor/ColumnExtractorSettersSpec.scala
@@ -255,31 +255,6 @@ class ColumnExtractorSettersSpec extends FlatSpec with Matchers {
     ))
   }
 
-  it should "return setters for CondExtractors" in {
-    val lessThanZero = (t: (Int, String)) => t._1 < 0
-    val greaterThanA = (t: (Int, String)) => t._2 > "a"
-    val fallBack = (t: (Int, String)) => true
-
-    val choiceExtractor = extractTuple(FirstTable.col1, FirstTable.col2).cond(
-      lessThanZero -> leftExtractor,
-      greaterThanA -> rightExtractor,
-      fallBack -> bothExtractor
-    )
-
-    choiceExtractor.settersFor(LeftExtracted(-1, "e", Some("a"))) should be(List(
-      Setter(FirstTable.col1, -1),
-      Setter(FirstTable.col2, "e"),
-      Setter(FirstTable.col3, Some("a"))
-    ))
-
-    choiceExtractor.settersFor(BothExtracted(45, "a", Some("f"), Some(12))) should be(List(
-      Setter(FirstTable.col1, 45),
-      Setter(FirstTable.col2, "a"),
-      Setter(FirstTable.col3, Some("f")),
-      Setter(FirstTable.col4, Some(12))
-    ))
-  }
-
   it should "throw an exception when there are ambiguous choices in a ChoiceExtractor" in {
     val nameExtractor = extract[Name](
       name = FirstTable.col2
@@ -308,6 +283,22 @@ class ColumnExtractorSettersSpec extends FlatSpec with Matchers {
 
     intercept[Exception] {
       choiceExtractor.settersFor(BothExtracted(-1, "e", Some("a"), None))
+    }
+  }
+
+  it should "throw an exception when used with a CondExtractor" in {
+    val lessThanZero = (t: (Int, String)) => t._1 < 0
+    val greaterThanA = (t: (Int, String)) => t._2 > "a"
+    val fallBack = (t: (Int, String)) => true
+
+    val choiceExtractor = extractTuple(FirstTable.col1, FirstTable.col2).cond(
+      lessThanZero -> leftExtractor,
+      greaterThanA -> rightExtractor,
+      fallBack -> bothExtractor
+    )
+
+    intercept[Exception] {
+      choiceExtractor.settersFor(LeftExtracted(-1, "e", Some("a")))
     }
   }
 


### PR DESCRIPTION
This allows syntax like:
```scala
val leftExtractor = extract[LeftExtracted](
  intExtractor,
  stringExtractor
)

val rightExtractor = extract[RightExtracted](
  intExtractor,
  stringExtractor
)

val bothExtractor = extract[BothExtracted](
  intExtractor,
  stringExtractor
)

val lessThanZero = (t: (Shape, Int, String)) => t._2 < 0
val greaterThanA = (t: (Shape, Int, String)) => t._3 > "a"
val fallBack = (t: (Shape, Int, String)) => true

val choiceExtractor = extractTuple(shapeExtractor, intExtractor, stringExtractor).cond(
  lessThanZero -> leftExtractor,
  greaterThanA -> rightExtractor,
  fallBack -> bothExtractor
)
```
Comments appreciated 

Still need:
* ~~Tests for `cond`~~
* Better method names
* ~~To make sure ChoiceExtractor isn't way too inefficient~~ It should no longer call `inner` all the time
* ~~A better interface for `cond` and `switch` that permits variance - generate methods from 2 to 22 args and use productIterator?~~
* Advice on ~~ColumnExtractorSetters, ExtractorFinder, ColumnExtractorSyntax~~
