### PR TITLE
Implement ScalarFunction0 and KeywordFunction

### DIFF
--- a/sqlest/src/main/boilerplate/sqlest/ast/ScalarFunctions.scala.template
+++ b/sqlest/src/main/boilerplate/sqlest/ast/ScalarFunctions.scala.template
@@ -18,22 +18,32 @@ package sqlest.ast
 
 trait ScalarFunctions {
 
+  def KeywordFunction[R: ColumnType](name: String) = KeywordFunctionColumn[R](name).as(name)
+
+  abstract class ScalarFunctionColumn0[R: ColumnType] {
+    def apply(): AliasedColumn[R]
+  }
+
+  def ScalarFunction0[R: ColumnType](name: String) = new ScalarFunctionColumn0[R] {
+    def apply() = ScalarFunctionColumn[R](name, Nil).as(name)
+  }
+
   abstract class ScalarFunctionColumnN[A, R: ColumnType] {
-    def apply(columns: Column[A]*): ScalarFunctionColumn[R]
+    def apply(columns: Column[A]*): AliasedColumn[R]
   }
 
   def ScalarFunctionN[A, R: ColumnType](name: String) = new ScalarFunctionColumnN[A, R] {
     def apply(columns: Column[A]*) =
-      ScalarFunctionColumn[R](name, columns)
+      ScalarFunctionColumn[R](name, columns).as(name)
   }
 
 [#  abstract class ScalarFunctionColumn1[[#A1#], R: ColumnType] {
-    def apply[[#B1#]]([#column1: Column[B1]#])(implicit [#column1Equivalence: ColumnTypeEquivalence[A1, B1]#]): ScalarFunctionColumn[R]
+    def apply[[#B1#]]([#column1: Column[B1]#])(implicit [#column1Equivalence: ColumnTypeEquivalence[A1, B1]#]): AliasedColumn[R]
   }
 
   def ScalarFunction1[[#A1#], R: ColumnType](name: String) = new ScalarFunctionColumn1[[#A1#], R] {
     def apply[[#B1#]]([#column1: Column[B1]#])(implicit [#column1Equivalence: ColumnTypeEquivalence[A1, B1]#]) =
-      ScalarFunctionColumn[R](name, Seq([#column1#]))
+      ScalarFunctionColumn[R](name, Seq([#column1#])).as(name)
   }#
 
 ]

--- a/sqlest/src/main/scala/sqlest/ast/Column.scala
+++ b/sqlest/src/main/scala/sqlest/ast/Column.scala
@@ -75,6 +75,11 @@ case class NotExistsColumn(select: Select[_, _ <: Relation]) extends Column[Bool
 case class ScalarFunctionColumn[A](name: String, parameters: Seq[Column[_]])(implicit val columnType: ColumnType[A]) extends Column[A]
 
 /**
+ * A KeywordFunctionColumn represents a
+ */
+case class KeywordFunctionColumn[A](name: String)(implicit val columnType: ColumnType[A]) extends Column[A]
+
+/**
  * A column that has an alias associated with it.
  *
  * The columns selected by a relation must all have aliases.

--- a/sqlest/src/main/scala/sqlest/ast/operations/ColumnOperations.scala
+++ b/sqlest/src/main/scala/sqlest/ast/operations/ColumnOperations.scala
@@ -69,6 +69,7 @@ object ColumnOperations {
       case windowFunctionColumn: WindowFunctionColumn => f(WindowFunctionColumn(windowFunctionColumn.partitionByColumns.map(_.mapColumns(f, selectFunction)), windowFunctionColumn.orderBy.map(_.mapColumns(f, selectFunction)))).asInstanceOf[Column[A]]
       case selectColumn: SelectColumn[A] => SelectColumn(selectFunction(selectColumn.select).asInstanceOf[Select[AliasedColumn[A], _ <: Relation]])(selectColumn.columnType).asInstanceOf[Column[A]]
       case scalarFunctionColumn: ScalarFunctionColumn[A] => f(ScalarFunctionColumn(scalarFunctionColumn.name, scalarFunctionColumn.parameters.map(_.mapColumns(f, selectFunction)))(scalarFunctionColumn.columnType)).asInstanceOf[Column[A]]
+      case keywordFunctionColumn: KeywordFunctionColumn[A] => f(KeywordFunctionColumn(keywordFunctionColumn.name)(keywordFunctionColumn.columnType)).asInstanceOf[Column[A]]
       case tableColumn: TableColumn[A] => f(tableColumn).asInstanceOf[Column[A]]
       case aliasColumn: AliasColumn[A] => f(AliasColumn(aliasColumn.column.mapColumns(f, selectFunction), aliasColumn.columnAlias)(aliasColumn.columnType)).asInstanceOf[Column[A]]
       case referenceColumn: ReferenceColumn[A] => f(referenceColumn).asInstanceOf[Column[A]]

--- a/sqlest/src/main/scala/sqlest/ast/syntax/ScalarFunctionSyntax.scala
+++ b/sqlest/src/main/scala/sqlest/ast/syntax/ScalarFunctionSyntax.scala
@@ -26,4 +26,5 @@ trait ScalarFunctionSyntax extends ScalarFunctions {
 
   def connectByRoot[A](column: Column[A]) = ScalarFunctionColumn[A]("connect_by_root", Seq(column))(column.columnType)
   def prior[A](column: Column[A]) = ScalarFunctionColumn[A]("prior", Seq(column))(column.columnType)
+  val level = KeywordFunction[Int]("level")
 }

--- a/sqlest/src/main/scala/sqlest/sql/base/BaseStatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/BaseStatementBuilder.scala
@@ -90,6 +90,7 @@ trait BaseStatementBuilder {
       case NotExistsColumn(select) => "not exists (" + selectSql(aliasColumnsFromSubselects(select).asInstanceOf[Select[_, _ <: Relation]]) + ")"
       case WindowFunctionColumn(partitionByColumns, orders) => windowFunctionSql(partitionByColumns, orders)
       case column: ScalarFunctionColumn[_] => functionSql(column.name, column.parameters)
+      case column: KeywordFunctionColumn[_] => column.name
       case column: TableColumn[_] => identifierSql(column.tableAlias) + "." + identifierSql(column.columnName)
       case column: AliasColumn[_] => columnSql(column.column)
       case column: ReferenceColumn[_] => column.columnAlias
@@ -204,6 +205,7 @@ trait BaseStatementBuilder {
     case PostfixFunctionColumn(_, a) => columnArgs(a)
     case DoubleInfixFunctionColumn(_, _, a, b, c) => columnArgs(a) ++ columnArgs(b) ++ columnArgs(c)
     case ScalarFunctionColumn(_, parameters) => parameters.toList flatMap columnArgs
+    case column: KeywordFunctionColumn[_] => Nil
     case WindowFunctionColumn(columns, orders) => columns.toList.flatMap(columnArgs) ++ orders.toList.flatMap(order => columnArgs(order.column))
     case SelectColumn(select) => selectArgs(select)
     case ExistsColumn(select) => selectArgs(select)

--- a/sqlest/src/test/scala/sqlest/sql/SelectStatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/SelectStatementBuilderSpec.scala
@@ -16,6 +16,7 @@
 
 package sqlest.sql
 
+import org.joda.time.LocalDate
 import org.scalatest._
 import org.scalatest.matchers._
 import sqlest._
@@ -326,6 +327,20 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
        |from three
        """.formatSql,
       List(List("abc"))
+    )
+  }
+
+  "select zero-arg scalar function and keyword function" should "produce the right sql" in {
+    val date = ScalarFunction0[LocalDate]("date")
+    sql {
+      select(level, date())
+        .from(TableThree)
+    } should equal(
+      s"""
+       |select level as level, date() as date
+       |from three
+       """.formatSql,
+      List(Nil)
     )
   }
 


### PR DESCRIPTION
There are some functions that can't be expressed at the moment in sqlest, such as `date()` and `level`.
This change allows them:
```scala
  val date = ScalarFunction0[LocalDate]("date")
  val level = KeywordFunction[Int]("level")
```
