### PR TITLE
Implement untyped operators for mapped column types

### DIFF
--- a/sqlest/src/main/scala/sqlest/ast/syntax/UntypedColumnSyntax.scala
+++ b/sqlest/src/main/scala/sqlest/ast/syntax/UntypedColumnSyntax.scala
@@ -31,17 +31,16 @@ class UntypedColumnHelpers extends ColumnSyntax {
   }
 
   def infixExpression[A](op: String, left: Column[A], right: String, columnType: ColumnType[A])(implicit U: UntypedReads[A]): Option[InfixFunctionColumn[Boolean]] =
-    mappedArgument(right, columnType).map(r => InfixFunctionColumn[Boolean](op, left, LiteralColumn(r)(columnType.asInstanceOf[ColumnType[U.Read]])))
+    mappedArgument(right, columnType).map(r => InfixFunctionColumn[Boolean](op, left, LiteralColumn(r)(columnType.asInstanceOf[ColumnType[A]])))
 
   def likeExpression[A](left: Column[A], right: String, columnType: ColumnType[A], formatArgument: String => String)(implicit U: UntypedReads[A]): Option[InfixFunctionColumn[Boolean]] =
-    mappedArgument(formatArgument(right), columnType).map(r => InfixFunctionColumn[Boolean]("like", left, LiteralColumn(r)(columnType.asInstanceOf[ColumnType[U.Read]])))
+    mappedArgument(formatArgument(right), columnType).map(r => InfixFunctionColumn[Boolean]("like", left, LiteralColumn(r)(columnType.asInstanceOf[ColumnType[A]])))
 
   def likeEncode(str: String) =
     str.replaceAll("([%_^])", "^$1")
 }
 
 trait UntypedColumnSyntax {
-
   implicit class UntypedColumnOps[A](left: Column[A])(implicit U: UntypedReads[A]) {
     val helpers = new UntypedColumnHelpers
 
@@ -55,7 +54,7 @@ trait UntypedColumnSyntax {
     def untypedIn(right: List[String]) = {
       val mappedValues = right.map(value => helpers.mappedArgument(value, left.columnType))
       if (mappedValues.forall(_.isDefined)) {
-        val inColumns = mappedValues.flatten.map(value => LiteralColumn(value)(left.columnType.asInstanceOf[ColumnType[U.Read]]))
+        val inColumns = mappedValues.flatten.map(value => LiteralColumn(value)(left.columnType.asInstanceOf[ColumnType[A]]))
         Some(InfixFunctionColumn[Boolean]("in", left, ScalarFunctionColumn("", inColumns)(left.columnType)))
       } else
         None

--- a/sqlest/src/main/scala/sqlest/ast/syntax/UntypedReads.scala
+++ b/sqlest/src/main/scala/sqlest/ast/syntax/UntypedReads.scala
@@ -1,0 +1,72 @@
+package sqlest.ast.syntax
+
+import org.joda.time.{ DateTime, LocalDate }
+import scala.util.Try
+import sqlest.ast._
+import sqlest.util.Iso8601
+
+trait UntypedReads[A] {
+  type Read
+  def reads(s: String): Option[Read]
+}
+
+object UntypedReads {
+  type Aux[A, B] = UntypedReads[A] { type Read = B }
+
+  object DefaultInstances {
+    implicit val untypedBoolean = new UntypedReads[Boolean] {
+      type Read = Boolean
+      def reads(s: String) = s.trim.toLowerCase match {
+        case "true" => Some(true)
+        case "false" => Some(false)
+        case _ => None
+      }
+    }
+
+    implicit val untypedString = new UntypedReads[String] {
+      type Read = String
+      def reads(s: String) = Some(s)
+    }
+
+    implicit val untypedInt = new UntypedReads[Int] {
+      type Read = Int
+      def reads(s: String) = Try(s.toInt).toOption
+    }
+
+    implicit val untypedLong = new UntypedReads[Long] {
+      type Read = Long
+      def reads(s: String) = Try(s.toLong).toOption
+    }
+
+    implicit val untypedDouble = new UntypedReads[Double] {
+      type Read = Double
+      def reads(s: String) = Try(s.toDouble).toOption
+    }
+
+    implicit val untypedBigDecimal = new UntypedReads[BigDecimal] {
+      type Read = BigDecimal
+      def reads(s: String) = Try(BigDecimal(s)).toOption
+    }
+
+    implicit val untypedDateTime = new UntypedReads[DateTime] {
+      type Read = DateTime
+      def reads(s: String) = Iso8601.unapply(s)
+    }
+
+    implicit val untypedLocalDate = new UntypedReads[LocalDate] {
+      type Read = LocalDate
+      def reads(s: String) = Iso8601.unapply(s).map(new LocalDate(_))
+    }
+
+    implicit val untypedByteArray = new UntypedReads[Array[Byte]] {
+      type Read = Array[Byte]
+      def reads(s: String) = Try(javax.xml.bind.DatatypeConverter.parseHexBinary(s)).toOption
+    }
+
+    implicit def untypedOption[A, B](implicit U: UntypedReads.Aux[A, B]) = new UntypedReads[Option[A]] {
+      type Read = Option[B]
+      def reads(s: String) = U.reads(s).map(Some(_))
+    }
+  }
+}
+

--- a/sqlest/src/main/scala/sqlest/ast/syntax/UntypedReads.scala
+++ b/sqlest/src/main/scala/sqlest/ast/syntax/UntypedReads.scala
@@ -6,67 +6,51 @@ import sqlest.ast._
 import sqlest.util.Iso8601
 
 trait UntypedReads[A] {
-  type Read
-  def reads(s: String): Option[Read]
+  def reads(s: String): Option[A]
 }
 
 object UntypedReads {
-  type Aux[A, B] = UntypedReads[A] { type Read = B }
-
-  object DefaultInstances {
-    implicit val untypedBoolean = new UntypedReads[Boolean] {
-      type Read = Boolean
-      def reads(s: String) = s.trim.toLowerCase match {
-        case "true" => Some(true)
-        case "false" => Some(false)
-        case _ => None
-      }
-    }
-
-    implicit val untypedString = new UntypedReads[String] {
-      type Read = String
-      def reads(s: String) = Some(s)
-    }
-
-    implicit val untypedInt = new UntypedReads[Int] {
-      type Read = Int
-      def reads(s: String) = Try(s.toInt).toOption
-    }
-
-    implicit val untypedLong = new UntypedReads[Long] {
-      type Read = Long
-      def reads(s: String) = Try(s.toLong).toOption
-    }
-
-    implicit val untypedDouble = new UntypedReads[Double] {
-      type Read = Double
-      def reads(s: String) = Try(s.toDouble).toOption
-    }
-
-    implicit val untypedBigDecimal = new UntypedReads[BigDecimal] {
-      type Read = BigDecimal
-      def reads(s: String) = Try(BigDecimal(s)).toOption
-    }
-
-    implicit val untypedDateTime = new UntypedReads[DateTime] {
-      type Read = DateTime
-      def reads(s: String) = Iso8601.unapply(s)
-    }
-
-    implicit val untypedLocalDate = new UntypedReads[LocalDate] {
-      type Read = LocalDate
-      def reads(s: String) = Iso8601.unapply(s).map(new LocalDate(_))
-    }
-
-    implicit val untypedByteArray = new UntypedReads[Array[Byte]] {
-      type Read = Array[Byte]
-      def reads(s: String) = Try(javax.xml.bind.DatatypeConverter.parseHexBinary(s)).toOption
-    }
-
-    implicit def untypedOption[A, B](implicit U: UntypedReads.Aux[A, B]) = new UntypedReads[Option[A]] {
-      type Read = Option[B]
-      def reads(s: String) = U.reads(s).map(Some(_))
+  implicit val untypedBoolean = new UntypedReads[Boolean] {
+    def reads(s: String) = s.trim.toLowerCase match {
+      case "true" => Some(true)
+      case "false" => Some(false)
+      case _ => None
     }
   }
-}
 
+  implicit val untypedString = new UntypedReads[String] {
+    def reads(s: String) = Some(s)
+  }
+
+  implicit val untypedInt = new UntypedReads[Int] {
+    def reads(s: String) = Try(s.toInt).toOption
+  }
+
+  implicit val untypedLong = new UntypedReads[Long] {
+    def reads(s: String) = Try(s.toLong).toOption
+  }
+
+  implicit val untypedDouble = new UntypedReads[Double] {
+    def reads(s: String) = Try(s.toDouble).toOption
+  }
+
+  implicit val untypedBigDecimal = new UntypedReads[BigDecimal] {
+    def reads(s: String) = Try(BigDecimal(s)).toOption
+  }
+
+  implicit val untypedDateTime = new UntypedReads[DateTime] {
+    def reads(s: String) = Iso8601.unapply(s)
+  }
+
+  implicit val untypedLocalDate = new UntypedReads[LocalDate] {
+    def reads(s: String) = Iso8601.unapply(s).map(new LocalDate(_))
+  }
+
+  implicit val untypedByteArray = new UntypedReads[Array[Byte]] {
+    def reads(s: String) = Try(javax.xml.bind.DatatypeConverter.parseHexBinary(s)).toOption
+  }
+
+  implicit def untypedOption[A](implicit U: UntypedReads[A]) = new UntypedReads[Option[A]] {
+    def reads(s: String) = U.reads(s).map(Some(_))
+  }
+}

--- a/sqlest/src/test/scala/sqlest/untyped/ast/ColumnSpec.scala
+++ b/sqlest/src/test/scala/sqlest/untyped/ast/ColumnSpec.scala
@@ -23,8 +23,6 @@ import sqlest._
 import sqlest.ast.syntax.UntypedReads
 
 class ColumnSpec extends FlatSpec with Matchers {
-  import UntypedReads.DefaultInstances._
-
   class TableOne(alias: Option[String]) extends Table("one", alias) {
     val intCol = column[Int]("intCol")
     val longCol = column[Long]("Col")


### PR DESCRIPTION
Not sure whether I'm happy with the `DefaultInstances` thing.

However, if a library user supplies an `UntypedReads` instance for all `A` they would not want to use the defaults.