### PR TITLE
Add `withTransactionAsync` for async rollback support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,6 @@ lazy val commonSettings = SbtScalariform.scalariformSettings ++ publishingSettin
     "-language:implicitConversions",
     "-unchecked",
     "-Xfatal-warnings",
-    "-Yinline-warnings",
-    "-Ywarn-dead-code",
     "-Xfuture"
   ),
   coverageExcludedPackages := "sqlest.examples",

--- a/sqlest/src/test/scala/sqlest/executor/AbstractConnection.scala
+++ b/sqlest/src/test/scala/sqlest/executor/AbstractConnection.scala
@@ -19,6 +19,9 @@ package sqlest.executor
 import java.sql.Connection
 
 trait AbstractConnection extends Connection {
+  var closed: Boolean
+  var committed: Boolean
+  var rolledBack: Boolean
   def abort(x$1: java.util.concurrent.Executor): Unit = ???
   def clearWarnings(): Unit = ???
   def close(): Unit = ???


### PR DESCRIPTION
It's currently quite easy for users to unintentionally trigger rollback on a closed connection if they are using `withTransaction` with a method `Transaction => Future[_]` - `withTransactionAsync` supports this by closing the connection only once the Future completes.

/cc @brendanator @p14n @RobertEMackay