### PR TITLE
Rename to avoid name collision

### DIFF
--- a/sqlest/src/main/scala/sqlest/ast/syntax/TableFunctionSyntax.scala
+++ b/sqlest/src/main/scala/sqlest/ast/syntax/TableFunctionSyntax.scala
@@ -21,7 +21,7 @@ import sqlest.ast._
 trait TableFunctionSyntax {
 
   /** Temporary table for a statement: `.leftJoin(table(select(...))).as(...)`. */
-  def table[A, R <: Relation](select: Select[A, R]) = new TableFunctionFromSelectBuilder(select)
+  def tableFunction[A, R <: Relation](select: Select[A, R]) = new TableFunctionFromSelectBuilder(select)
 
   /** Helper class to prevent users writing `table()` without `.as(...)`. */
   class TableFunctionFromSelectBuilder[A, R <: Relation](select: Select[A, R]) {

--- a/sqlest/src/test/scala/sqlest/sql/DB2StatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/DB2StatementBuilderSpec.scala
@@ -142,7 +142,7 @@ class DB2StatementBuilderSpec extends BaseStatementBuilderSpec {
     sql {
       select(TableOne.col1, TableOne.col2, TableTwo.col2, TableTwo.col3)
         .from(TableOne)
-        .leftJoin(table(select(TableTwo.col2, TableTwo.col3).from(TableTwo).where(TableTwo.col2 === "123")).as("testTableFunctionFromSelect"))
+        .leftJoin(tableFunction(select(TableTwo.col2, TableTwo.col3).from(TableTwo).where(TableTwo.col2 === "123")).as("testTableFunctionFromSelect"))
         .on(TableOne.col2 === TableTwo.col2)
     } should equal(
       s"""

--- a/sqlest/src/test/scala/sqlest/sql/SelectStatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/SelectStatementBuilderSpec.scala
@@ -594,7 +594,7 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
       sql {
         select(TableOne.col1, TableOne.col2, TableTwo.col2, TableTwo.col3)
           .from(TableOne)
-          .leftJoin(table(select(TableTwo.col2, TableTwo.col3).from(TableTwo).where(TableTwo.col2 === "123")).as("testTableFunctionFromSelect"))
+          .leftJoin(tableFunction(select(TableTwo.col2, TableTwo.col3).from(TableTwo).where(TableTwo.col2 === "123")).as("testTableFunctionFromSelect"))
           .on(TableOne.col2 === TableTwo.col2)
       }
     }


### PR DESCRIPTION
table was causing name collision, so renamed to tableFunction