### PR TITLE
Pretty print SQL

### DIFF
--- a/sqlest/src/main/scala/sqlest/executor/Database.scala
+++ b/sqlest/src/main/scala/sqlest/executor/Database.scala
@@ -181,7 +181,9 @@ class Session(database: Database) extends Logging {
       if (argumentLists.size == 1) argumentLists.head.map(_.value).mkString(", ")
       else argumentLists.map(_.map(_.value).mkString("(", ", ", ")")).mkString(", ")
 
-    s"sql [$sql], arguments [$argumentsLog]${connectionLog}"
+    s"""sql [
+    |$sql
+    |], arguments [$argumentsLog]${connectionLog}""".stripMargin
   }
 }
 

--- a/sqlest/src/main/scala/sqlest/sql/H2StatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/H2StatementBuilder.scala
@@ -19,9 +19,9 @@ package sqlest.sql
 import sqlest.ast._
 
 trait H2StatementBuilder extends base.StatementBuilder {
-  override def groupSql(group: Group): String = group match {
+  override def groupSql(group: Group, indent: Int): String = group match {
     case group: FunctionGroup => throw new UnsupportedOperationException
-    case group => super.groupSql(group)
+    case group => super.groupSql(group, indent)
   }
 }
 

--- a/sqlest/src/main/scala/sqlest/sql/base/BaseStatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/BaseStatementBuilder.scala
@@ -20,9 +20,9 @@ import sqlest.ast._
 import sqlest.ast.operations.ColumnOperations._
 
 trait BaseStatementBuilder {
-  protected val MaxWidth = 40
-  protected val TabWidth = 4
-  protected val NewLine = System.lineSeparator
+  val MaxWidth = 40
+  val TabWidth = 4
+  val NewLine = System.lineSeparator
 
   def preprocess(operation: Operation): Operation =
     aliasColumnsFromSubselects(operation)

--- a/sqlest/src/main/scala/sqlest/sql/base/DeleteStatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/DeleteStatementBuilder.scala
@@ -19,20 +19,19 @@ package sqlest.sql.base
 import sqlest.ast._
 
 trait DeleteStatementBuilder extends BaseStatementBuilder {
-  def deleteSql(delete: Delete): String = {
+  def deleteSql(delete: Delete, indent: Int): String = {
     Seq(
-      "delete",
-      deleteFromSql(delete.from)
+      "delete " + deleteFromSql(delete.from)
     ) ++ Seq(
-        deleteWhereSql(delete.where)
-      ).flatten mkString ("", " ", "")
+        deleteWhereSql(delete.where, indent)
+      ).flatten mkString (NewLine + padding(indent))
   }
 
   def deleteFromSql(from: Table): String =
     s"from ${identifierSql(from.tableName)}"
 
-  def deleteWhereSql(where: Option[Column[Boolean]]): Option[String] =
-    where map (where => s"where ${columnSql(where)}")
+  def deleteWhereSql(where: Option[Column[Boolean]], indent: Int): Option[String] =
+    where map (where => s"where ${columnSql(where, indent)}")
 
   // -------------------------------------------------
 

--- a/sqlest/src/main/scala/sqlest/sql/base/InsertStatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/InsertStatementBuilder.scala
@@ -25,12 +25,12 @@ trait InsertStatementBuilder extends BaseStatementBuilder {
     case insert: InsertValues =>
       val insertColumns = insertColumnsSql(insert.columns)
       val insertValues = insertValuesSql(insert.columns)
-      withLineBreaks(insertColumns, indent)(s"insert ${insertIntoSql(insert.into)} (", ", ", ")") +
-        onNewLine(withLineBreaks(insertValues, indent)(s"values (", ", ", ")"), indent)
+      withLineBreaks(insertColumns, indent + TabWidth)(s"insert ${insertIntoSql(insert.into)} (", ", ", ")") +
+        onNewLine(withLineBreaks(insertValues, indent + 7)(s"values (", ", ", ")"), indent)
     case InsertFromSelect(into, columns, select) =>
       val insertColumns = insertColumnsSql(columns)
       val insertValues = insertValuesSql(columns)
-      withLineBreaks(insertColumns, indent)(s"insert ${insertIntoSql(into)} (", ", ", ")") +
+      withLineBreaks(insertColumns, indent + TabWidth)(s"insert ${insertIntoSql(into)} (", ", ", ")") +
         onNewLine(selectStatementBuilder.selectSql(select, indent), indent)
   }
 

--- a/sqlest/src/main/scala/sqlest/sql/base/StatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/StatementBuilder.scala
@@ -26,7 +26,9 @@ trait StatementBuilder extends BaseStatementBuilder
 
   def apply(operation: Operation) = {
     val preprocessedOperation = preprocess(operation)
-    (preprocessedOperation, sql(preprocessedOperation), argumentLists(preprocessedOperation))
+    val rawSql = sql(preprocessedOperation)
+    val argLists = argumentLists(preprocessedOperation)
+    (preprocessedOperation, rawSql, argLists, prettySql(rawSql, argLists))
   }
 
   def generateRawSql(operation: Operation): String = {
@@ -37,6 +39,51 @@ trait StatementBuilder extends BaseStatementBuilder
     querySql.zipAll(queryArguments, "", "")
       .map { case (sql, argument) => sql + argument }
       .mkString
+  }
+
+  private def prettySql(sql: String, argumentLists: List[List[LiteralColumn[_]]]): String = {
+    def literals(argList: List[LiteralColumn[_]]) = argList.map {
+      case literal: LiteralColumn[a] =>
+        constantSql(literal.columnType, literal.value)
+    }
+
+    val frags = sql.split("\\?")
+    val fragLen = frags.length
+
+    val firstArgs = argumentLists
+      .headOption
+      .toList
+      .flatMap(literals)
+
+    val firstArgsSql = frags.zipAll(firstArgs, "", "").flatMap {
+      case (l, r) => Seq(l, r)
+    }.mkString
+
+    val restArgLists =
+      if (firstArgs.isEmpty) Nil
+      else argumentLists
+        .drop(1)
+        .flatMap(literals)
+        .grouped(firstArgs.length)
+        .toList
+
+    val restArgListsSql = restArgLists.map { argList =>
+      withLineBreaks(argList, 7)("(", ", ", ")")
+    }
+
+    val restArgsSql =
+      if (restArgListsSql.isEmpty)
+        ""
+      else restArgListsSql.mkString(
+        "," + NewLine + padding(7),
+        "," + NewLine + padding(7),
+        ""
+      )
+
+    if (restArgsSql.isEmpty)
+      firstArgsSql
+    else
+      firstArgsSql + restArgsSql
   }
 
   private def sql(operation: Operation): String = operation match {

--- a/sqlest/src/main/scala/sqlest/sql/base/StatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/StatementBuilder.scala
@@ -40,10 +40,10 @@ trait StatementBuilder extends BaseStatementBuilder
   }
 
   private def sql(operation: Operation): String = operation match {
-    case select: Select[_, _] => selectSql(select)
-    case insert: Insert => insertSql(insert)
-    case update: Update => updateSql(update)
-    case delete: Delete => deleteSql(delete)
+    case select: Select[_, _] => selectSql(select, 0)
+    case insert: Insert => insertSql(insert, 0)
+    case update: Update => updateSql(update, 0)
+    case delete: Delete => deleteSql(delete, 0)
     case other => sys.error("Unsupported operation type: " + other)
   }
 

--- a/sqlest/src/main/scala/sqlest/sql/base/UpdateStatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/UpdateStatementBuilder.scala
@@ -19,23 +19,25 @@ package sqlest.sql.base
 import sqlest.ast._
 
 trait UpdateStatementBuilder extends BaseStatementBuilder {
-  def updateSql(update: Update): String = {
+  def updateSql(update: Update, indent: Int): String = {
     Seq(
       updateTableSql(update.table),
-      updateSetSql(update.set)
+      updateSetSql(update.set, indent)
     ) ++ Seq(
-        updateWhereSql(update.where)
-      ).flatten mkString ("", " ", "")
+        updateWhereSql(update.where, indent)
+      ).flatten mkString (NewLine + padding(indent))
   }
 
   def updateTableSql(table: Table): String =
     s"update ${identifierSql(table.tableName)}"
 
-  def updateSetSql(setters: Seq[Setter[_, _]]): String =
-    "set " + setters.map(setter => identifierSql(setter.column.columnName) + " = " + columnSql(setter.value)).mkString(", ")
+  def updateSetSql(setters: Seq[Setter[_, _]], indent: Int): String = {
+    val setterSql = setters.map(setter => identifierSql(setter.column.columnName) + " = " + columnSql(setter.value, indent))
+    withLineBreaks(setterSql, indent + TabWidth)("set ", ", ", "")
+  }
 
-  def updateWhereSql(where: Option[Column[Boolean]]): Option[String] =
-    where map (where => s"where ${columnSql(where)}")
+  def updateWhereSql(where: Option[Column[Boolean]], indent: Int): Option[String] =
+    where map (where => s"where ${columnSql(where, indent)}")
 
   // -------------------------------------------------
 

--- a/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
+++ b/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
@@ -303,7 +303,8 @@ class ExecutorSpec extends FlatSpec with Matchers {
 
   it should "generate raw SQL correctly" in {
     TestDatabase(testResultSet).statementBuilder.generateRawSql(optionInsertStatement) should equal(
-      "insert into three (col3, col4) values (1, null)"
+      """insert into three (col3, col4)
+      |values (1, null)""".stripMargin
     )
   }
 
@@ -313,7 +314,12 @@ class ExecutorSpec extends FlatSpec with Matchers {
       optionInsertStatement.execute
     }
 
-    testDatabase.preparedStatement.get.sql shouldBe "insert into three (col3, col4) values (?, ?)"
+    testDatabase.preparedStatement.get.sql shouldBe
+      """
+      |insert into three (col3, col4)
+      |values (?, ?)
+      """.trim.stripMargin
+
     testDatabase.preparedStatement.get.parameters shouldBe Map(1 -> 1, 2 -> null)
   }
 
@@ -325,19 +331,33 @@ class ExecutorSpec extends FlatSpec with Matchers {
 
   it should "generate raw SQL correctly" in {
     TestDatabase(testResultSet).statementBuilder.generateRawSql(mappedOptionInsertStatement1) should equal(
-      "insert into six (trimmedString) values ('a')"
+      """
+      |insert into six (trimmedString)
+      |values ('a')
+      """.trim.stripMargin
     )
 
     testDatabase.statementBuilder.generateRawSql(mappedOptionInsertStatement2) should equal(
-      "insert into six (trimmedString) values ('')"
+      """
+      |insert into six (trimmedString)
+      |values ('')
+      """.trim.stripMargin
     )
 
     testDatabase.statementBuilder.generateRawSql(mappedOptionSelectStatement1) should equal(
-      "select six.zeroIsNoneDateTime as six_zeroIsNoneDateTime from six where (six.zeroIsNoneDateTime = 0)"
+      """
+      |select six.zeroIsNoneDateTime as six_zeroIsNoneDateTime
+      |from six
+      |where (six.zeroIsNoneDateTime = 0)
+      """.trim.stripMargin
     )
 
     testDatabase.statementBuilder.generateRawSql(mappedOptionSelectStatement2) should equal(
-      "select six.zeroIsNoneDateTime as six_zeroIsNoneDateTime from six where (six.zeroIsNoneDateTime = 20150101)"
+      """
+      |select six.zeroIsNoneDateTime as six_zeroIsNoneDateTime
+      |from six
+      |where (six.zeroIsNoneDateTime = 20150101)
+      """.trim.stripMargin
     )
   }
 
@@ -348,14 +368,24 @@ class ExecutorSpec extends FlatSpec with Matchers {
       mappedOptionInsertStatement1.execute
     }
 
-    testDatabase.preparedStatement.get.sql shouldBe "insert into six (trimmedString) values (?)"
+    testDatabase.preparedStatement.get.sql shouldBe
+      """
+      |insert into six (trimmedString)
+      |values (?)
+      """.trim.stripMargin
+
     testDatabase.preparedStatement.get.parameters shouldBe Map(1 -> "a")
 
     testDatabase.withTransaction { implicit transaction =>
       mappedOptionInsertStatement2.execute
     }
 
-    testDatabase.preparedStatement.get.sql shouldBe "insert into six (trimmedString) values (?)"
+    testDatabase.preparedStatement.get.sql shouldBe
+      """
+      |insert into six (trimmedString)
+      |values (?)
+      """.trim.stripMargin
+
     testDatabase.preparedStatement.get.parameters shouldBe Map(1 -> "")
   }
 

--- a/sqlest/src/test/scala/sqlest/sql/BaseStatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/BaseStatementBuilderSpec.scala
@@ -23,13 +23,13 @@ import sqlest.ast._
 
 trait BaseStatementBuilderSpec extends FlatSpec with Matchers {
   implicit class StringFormatOps(sql: String) {
-    def formatSql = sql.trim.stripMargin.split(scala.util.Properties.lineSeparator).map(_.trim).mkString(" ")
+    def formatSql = sql.trim.stripMargin.replaceAll("\\s+", " ")
   }
   implicit def statementBuilder: StatementBuilder
 
   def sql(operation: Operation) = {
     val (_, generatedSql, parameters) = statementBuilder(operation)
-    (generatedSql, parameters.map(_.map(_.value)))
+    (generatedSql.replaceAll("\\s+", " "), parameters.map(_.map(_.value)))
   }
 
   // Test data ----------------------------------

--- a/sqlest/src/test/scala/sqlest/sql/BaseStatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/BaseStatementBuilderSpec.scala
@@ -28,7 +28,7 @@ trait BaseStatementBuilderSpec extends FlatSpec with Matchers {
   implicit def statementBuilder: StatementBuilder
 
   def sql(operation: Operation) = {
-    val (_, generatedSql, parameters) = statementBuilder(operation)
+    val (_, generatedSql, parameters, prettySql) = statementBuilder(operation)
     (generatedSql.replaceAll("\\s+", " "), parameters.map(_.map(_.value)))
   }
 

--- a/sqlest/src/test/scala/sqlest/sql/DB2StatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/DB2StatementBuilderSpec.scala
@@ -51,10 +51,11 @@ class DB2StatementBuilderSpec extends BaseStatementBuilderSpec {
         .offset(20)
     } should equal(
       s"""
-       |with subquery as
-       |(select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2, row_number() over () as rownum
-         |from mytable
-         |where (mytable.col1 = ?))
+       |with subquery as (
+       |  select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2, row_number() over () as rownum
+       |  from mytable
+       |  where (mytable.col1 = ?)
+       |)
        |select mytable_col1, mytable_col2
        |from subquery
        |where rownum >= ?
@@ -71,10 +72,12 @@ class DB2StatementBuilderSpec extends BaseStatementBuilderSpec {
         .page(2, 10)
     } should equal(
       s"""
-       |with subquery as
-       |(select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2, row_number() over () as rownum
-         |from mytable
-         |where (mytable.col1 = ?))
+       |with subquery as (
+       |  select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2,
+       |    row_number() over () as rownum
+       |  from mytable
+       |  where (mytable.col1 = ?)
+       |)
        |select mytable_col1, mytable_col2
        |from subquery
        |where rownum between ? and ?
@@ -92,10 +95,12 @@ class DB2StatementBuilderSpec extends BaseStatementBuilderSpec {
         .page(2, 10)
     } should equal(
       s"""
-       |with subquery as
-       |(select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2, row_number() over (order by mytable.col1) as rownum
-         |from mytable
-         |where (mytable.col1 = ?))
+       |with subquery as (
+       |  select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2,
+       |    row_number() over (order by mytable.col1) as rownum
+       |  from mytable
+       |  where (mytable.col1 = ?)
+       |)
        |select mytable_col1, mytable_col2
        |from subquery
        |where rownum between ? and ?
@@ -113,10 +118,12 @@ class DB2StatementBuilderSpec extends BaseStatementBuilderSpec {
         .page(15, 16)
     } should equal(
       s"""
-       |with subquery as
-       |(select 1 as a, sum(cast(? as integer)) as b, (3 + ?) as c, row_number() over (order by ?, ? desc) as rownum
-         |from one inner join two on ((? = ?) and (? <> ?))
-         |where ((? = ?) and (? <> ?)))
+       |with subquery as (
+       |  select 1 as a, sum(cast(? as integer)) as b, (3 + ?) as c,
+       |    row_number() over (order by ?, ? desc) as rownum
+       |  from one inner join two on ((? = ?) and (? <> ?))
+       |  where ((? = ?) and (? <> ?))
+       |)
        |select a, b, c
        |from subquery
        |where rownum between ? and ?
@@ -147,7 +154,10 @@ class DB2StatementBuilderSpec extends BaseStatementBuilderSpec {
     } should equal(
       s"""
          |select one.col1 as one_col1, one.col2 as one_col2, two_col2, two_col3
-         |from one left join table(select two.col2 as two_col2, two.col3 as two_col3 from two where (two.col2 = ?)) as testTableFunctionFromSelect
+         |from one left join table(
+         |  select two.col2 as two_col2, two.col3 as two_col3
+         |  from two where (two.col2 = ?)
+         |) as testTableFunctionFromSelect
          |on (one.col2 = two_col2)
        """.formatSql,
       List(List("123"))

--- a/sqlest/src/test/scala/sqlest/sql/InsertStatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/InsertStatementBuilderSpec.scala
@@ -66,17 +66,23 @@ class InsertStatementBuilderSpec extends BaseStatementBuilderSpec {
     sql {
       insert
         .into(TableOne)
-        .columns(TableOne.col1, TableOne.col2)
-        .values(TableOne.col1 -> "a", TableOne.col2 -> "b")
-        .values(TableOne.col1 -> "c", TableOne.col2 -> "d")
+        .columns(TableOne.col1, TableOne.col2, TableOne.col1, TableOne.col2, TableOne.col1, TableOne.col2)
+        .values(TableOne.col1 -> "a", TableOne.col2 -> "b", TableOne.col1 -> "a", TableOne.col2 -> "b", TableOne.col1 -> "a", TableOne.col2 -> "b")
+        .values(TableOne.col1 -> "c", TableOne.col2 -> "d", TableOne.col1 -> "c", TableOne.col2 -> "d", TableOne.col1 -> "c", TableOne.col2 -> "d")
+        .values(TableOne.col1 -> "e", TableOne.col2 -> "f", TableOne.col1 -> "e", TableOne.col2 -> "f", TableOne.col1 -> "e", TableOne.col2 -> "f")
+        .values(TableOne.col1 -> "g", TableOne.col2 -> "h", TableOne.col1 -> "g", TableOne.col2 -> "h", TableOne.col1 -> "g", TableOne.col2 -> "h")
     } should equal(
       s"""
        |insert
        |into one
-       |(col1, col2)
-       |values (?, ?)
+       |(col1, col2, col1, col2, col1, col2)
+       |values (?, ?, ?, ?, ?, ?)
        """.formatSql,
-      List(List("a", "b"), List("c", "d"))
+      List(
+        List("a", "b", "a", "b", "a", "b"),
+        List("c", "d", "c", "d", "c", "d"),
+        List("e", "f", "e", "f", "e", "f"),
+        List("g", "h", "g", "h", "g", "h"))
     )
   }
 

--- a/sqlest/src/test/scala/sqlest/sql/SelectStatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/SelectStatementBuilderSpec.scala
@@ -383,7 +383,10 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
       s"""
        |select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
        |from mytable
-       |where (mytable.col1 = (select mytable.col1 as mytable_col1 from mytable))
+       |where (mytable.col1 = (
+       |  select mytable.col1 as mytable_col1
+       |  from mytable
+       |))
        """.formatSql,
       List(Nil)
     )
@@ -436,9 +439,10 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
     } should equal(
       s"""
        |select mytable_col1, mytable_col2
-       |from
-       |  (select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
-       |   from mytable) as subselect
+       |from (
+       |  select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
+       |  from mytable
+       |) as subselect
        """.formatSql,
       List(Nil)
     )
@@ -454,12 +458,14 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
     } should equal(
       s"""
        |select mytable_col1, mytable_col2
-       |from mytable 
-       |cross join lateral 
-       |  (select mytable_col1, mytable_col2
-       |    from
-       |    (select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
-       |     from mytable) as subselect2) as subselect1
+       |from mytable
+       |cross join lateral (
+       |  select mytable_col1, mytable_col2
+       |  from (
+       |    select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
+       |    from mytable
+       |  ) as subselect2
+       |) as subselect1
        """.formatSql,
       List(Nil)
     )
@@ -475,12 +481,14 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
     } should equal(
       s"""
        |select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
-       |from mytable 
-       |where exists 
-       |  (select mytable_col1, mytable_col2
-       |    from
-       |    (select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
-       |     from mytable) as subselect2)
+       |from mytable
+       |where exists (
+       |  select mytable_col1, mytable_col2
+       |  from (
+       |    select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
+       |    from mytable
+       |  ) as subselect2
+       |)
        """.formatSql,
       List(Nil)
     )
@@ -496,12 +504,14 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
     } should equal(
       s"""
        |select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
-       |from mytable 
-       |where not exists 
-       |  (select mytable_col1, mytable_col2
-       |    from
-       |    (select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
-       |     from mytable) as subselect2)
+       |from mytable
+       |where not exists (
+       |  select mytable_col1, mytable_col2
+       |  from (
+       |    select mytable.col1 as mytable_col1, mytable.col2 as mytable_col2
+       |    from mytable
+       |  ) as subselect2
+       |)
        """.formatSql,
       List(Nil)
     )
@@ -513,7 +523,7 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
         .from(MyTable)
     } should equal(
       s"""
-       |select (rownumber()  over()) as rownumber
+       |select (rownumber() over()) as rownumber
        |from mytable
        """.formatSql,
       List(Nil)
@@ -524,7 +534,7 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
         .from(MyTable)
     } should equal(
       s"""
-       |select (rownumber()  over(partition by mytable.col1 order by mytable.col2)) as rownumber
+       |select (rownumber() over(partition by mytable.col1 order by mytable.col2)) as rownumber
        |from mytable
        """.formatSql,
       List(Nil)
@@ -542,8 +552,11 @@ class SelectStatementBuilderSpec extends BaseStatementBuilderSpec {
       s"""
        |select mytable.col1 as mytable_col1
        |from mytable
-       |inner join (select (rownumber()  over(partition by mytable.col1 order by mytable.col2)) as rownumber from mytable)
-       |  on (rownumber = 1)
+       |inner join (
+       |  select (rownumber() over(partition by mytable.col1 order by mytable.col2)) as rownumber
+       |  from mytable
+       |)
+       |on (rownumber = 1)
        """.formatSql,
       List(Nil)
     )


### PR DESCRIPTION
This is a POC to see what the output would look like. Samples from the tests:
```sql
with subquery as (
    select 1 as a, sum(cast(2 as integer)) as b,
        (3 + 4) as c,
        row_number() over (order by 13, 14 desc) as rownum
    from one
    inner join two
    on ((5 = 6) and (7 <> 8))
    where ((9 = 10) and (11 <> 12))
)
select a, b, c
from subquery
where rownum between 241 and 256

update one
set col1 = 'a', col2 = 'b'
where (('c' = 'd') and ('e' = 'f'))

select one.col1 as one_col1,
    one.col2 as one_col2,
    two.col2 as two_col2,
    two.col3 as two_col3,
    three.col3 as three_col3,
    three.col4 as three_col4
from one
inner join two
on (one.col2 = two.col2)
inner join three
on (two.col3 = three.col3)

select
    case
        when (mytable.col1 = 1) then 2
        when (mytable.col2 = 2) then 3
    end as case
from mytable

select mytable.col1 as mytable_col1,
    mytable.col2 as mytable_col2
from mytable
where not exists (
    select mytable_col1, mytable_col2
    from (
        select mytable.col1 as mytable_col1,
            mytable.col2 as mytable_col2
        from mytable
    ) as subselect2
)

insert into one (col1, col2, col1, col2, col1,
    col2)
values ('a', 'b', 'a', 'b', 'a', 'b'),
       ('c', 'd', 'c', 'd', 'c', 'd'),
       ('e', 'f', 'e', 'f', 'e', 'f'),
       ('g', 'h', 'g', 'h', 'g', 'h')
```
I'm not sure how comfortable I am with these changes being in the StatementBuilder itself, but couldn't find a self-contained SQL formatting lib or ANTLR grammar that supports ANSI SQL syntax.