### PR TITLE
Cast null to a type when it is a result of an empty Option (necessary…

### DIFF
--- a/sqlest/src/test/scala/sqlest/sql/DB2StatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/DB2StatementBuilderSpec.scala
@@ -235,6 +235,19 @@ class DB2StatementBuilderSpec extends BaseStatementBuilderSpec {
     )
   }
 
+  it should "produce the right SQL for nullable literal columns" in {
+    sql {
+      select(TableThree.col3, TableThree.col4, Option.empty[String].constant.as("testOption"))
+        .from(TableThree)
+    } should equal(
+      s"""
+         |select three.col3 as three_col3, three.col4 as three_col4, cast(null as varchar(256)) as testOption
+         |from three
+       """.formatSql,
+      List(List())
+    )
+  }
+
   "boolean columns" should "produce the right sql" in {
     sql {
       select(MyTable.col1)


### PR DESCRIPTION
… for DB2 SQL)

Casting only seemed to be necessary for Constant Columns that were options. The addTypingToLiteralColumn method (formerly addTypingToSqlColumn) seems to be necessary because to keep existing tests passing we should only be casting literals that are inside scalar functions and joins, so this function is called from those cases only.

I wanted to use OptionColumnType#isNull to check whether the column's value is null rather than checking explicitly for equality with None or null, but it always threw these type errors when I passed the column's value to that method:
```
[error]  found   : constantColumn.value.type (with underlying type _)
[error]  required: optionColumnType.baseColumnType.type
```