### PR TITLE
fix error messages for empty results when extractor is non-empty

### DIFF
--- a/sqlest/src/main/scala/sqlest/ast/Column.scala
+++ b/sqlest/src/main/scala/sqlest/ast/Column.scala
@@ -117,6 +117,8 @@ sealed trait AliasedColumn[A] extends Column[A] with CellExtractor[ResultSet, A]
     }
   }
 
+  override def checkNullValueAndGet[T](t: Option[T]) =
+    t.getOrElse(throw new NullPointerException(s"Tried to extract a null value without an OptionExtractor for column " + columnAlias))
 }
 
 /** Columns from tables. */

--- a/sqlest/src/test/scala/sqlest/extractor/ColumnExtractorSpec.scala
+++ b/sqlest/src/test/scala/sqlest/extractor/ColumnExtractorSpec.scala
@@ -864,4 +864,14 @@ class ColumnExtractorSpec extends FlatSpec with Matchers {
     ))
   }
 
+  "columns extracting empty data when not expected" should "throw error with column type" in {
+    def results = TestResultSet(TableOne.columns)(
+      Seq(null, null)
+    )
+
+    val exception = intercept[NullPointerException] {
+      TableOne.col1.extractHeadOption(results)
+    }
+    assert(exception.getMessage.contains("one_col1"))
+  }
 }


### PR DESCRIPTION
just using the column alias to give a little more info on what is causing the problem