### PR TITLE
Add extractCaseClass syntax

### DIFF
--- a/examples/src/main/scala/extractors/examples/CsvExtractors.scala
+++ b/examples/src/main/scala/extractors/examples/CsvExtractors.scala
@@ -79,12 +79,20 @@ object CSVExtractorExample extends App with ExtractorSyntax[CSVRow] {
   // Create extractors to read the domain classes
   val addressExtractor = extract[Address](houseExtractor, streetExtractor)
 
+  val addressExtractor2 = extractCaseClass(houseExtractor, streetExtractor)(Address.apply)
+
   // Named arguments often enhance the readibility of extractor definitions
   val personExtractor = extract[Person](
     name = nameExtractor,
     age = ageExtractor,
     address = addressExtractor.asOption
   ) // If any value read by the addressExtractor is null, None will be returned
+
+  val personExtractor2 = extractCaseClass(
+    nameExtractor,
+    ageExtractor,
+    addressExtractor2.asOption
+  )(Person.apply)
 
   println(addressExtractor.extractHeadOption(parsedCsv))
   // => Some(Address(1, Old Kent Road))

--- a/extractors/src/main/boilerplate/sqlest/extractor/ExtractorSyntax.scala.template
+++ b/extractors/src/main/boilerplate/sqlest/extractor/ExtractorSyntax.scala.template
@@ -37,4 +37,10 @@ trait ExtractorSyntax[Row] {
     new Tuple1Extractor[Row, [#A1#]]([#e1#])#
 
 ]
+
+[2..22#  def extractCaseClass[Row, A, [#B1#]]([#e1: Extractor[Row, B1]#])(fn: ([#B1#]) => A): MappedExtractor[Row, ([#B1#]), A] =
+    MappedExtractor(new Tuple1Extractor([#e1#]), fn.tupled)#
+
+]
+
 }

--- a/extractors/src/test/scala/sqlest/extractor/CaseClassExtractorMacroSpec.scala
+++ b/extractors/src/test/scala/sqlest/extractor/CaseClassExtractorMacroSpec.scala
@@ -244,7 +244,7 @@ class CaseClassExtractorMacroSpec extends FlatSpec with Matchers with ExtractorS
         a = intExtractor,
         b = stringExtractor
       ),
-      two = extract(twoExtractor)
+      two = twoExtractor
     )
 
     badNestedExtractor.extractHeadOption(tupleRows) should equal(Some(

--- a/extractors/src/test/scala/sqlest/extractor/ExtractorSpec.scala
+++ b/extractors/src/test/scala/sqlest/extractor/ExtractorSpec.scala
@@ -112,6 +112,27 @@ class ExtractorSpec extends FlatSpec with Matchers with ExtractorSyntax[Seq[Any]
     }
   }
 
+  it should "provide syntax for extracting case classes via extractCaseClass" in {
+    val seqRows = List(Seq(0, "hello"), Seq(2, "bye"), Seq(4, "level"))
+
+    case class Triple(a: Int, b: String, c: Boolean)
+
+    val tripleExtractor: MappedExtractor[Seq[Any], (Int, String, Boolean), Triple] =
+      extractCaseClass(
+        intExtractorAtIndex(0),
+        stringExtractorAtIndex(1).map(_.reverse),
+        intExtractorAtIndex(0).map(_ == 2)
+      )(Triple.apply)
+
+    tripleExtractor.extractHeadOption(Nil) should be(None)
+    tripleExtractor.extractHeadOption(seqRows) should be(Some(Triple(0, "olleh", false)))
+    tripleExtractor.extractAll(seqRows) should be(List(
+      Triple(0, "olleh", false),
+      Triple(2, "eyb", true),
+      Triple(4, "level", false)
+    ))
+  }
+
   it should "upcast safely with asA" in {
     val seqRows = List(Seq(0, "hello"), Seq(2, "bye"), Seq(4, "level"))
 


### PR DESCRIPTION
We're trying to reduce our reliance on Scala macros given their generally poor IDE support and impending deprecation.

This adds a pretty simple alternative syntax for extracting case classes:

```scala
  // before
  val personExtractor = extract[Person](
    name = nameExtractor,
    age = ageExtractor,
    address = addressExtractor.asOption
  )

  // after
  val personExtractor2 = extractCaseClass(
    nameExtractor,
    ageExtractor,
    addressExtractor.asOption
  )(Person.apply)
```