### PR TITLE
Update Table sql should use the table alias

### DIFF
--- a/sqlest/src/main/scala/sqlest/sql/base/UpdateStatementBuilder.scala
+++ b/sqlest/src/main/scala/sqlest/sql/base/UpdateStatementBuilder.scala
@@ -29,7 +29,10 @@ trait UpdateStatementBuilder extends BaseStatementBuilder {
   }
 
   def updateTableSql(table: Table): String =
-    s"update ${identifierSql(table.tableName)}"
+    if (table.tableName == table.tableAlias)
+      s"update ${identifierSql(table.tableName)}"
+    else
+      "update " + identifierSql(table.tableName) + " as " + identifierSql(table.tableAlias)
 
   def updateSetSql(setters: Seq[Setter[_, _]]): String =
     "set " + setters.map(setter => identifierSql(setter.column.columnName) + " = " + columnSql(setter.value)).mkString(", ")

--- a/sqlest/src/test/scala/sqlest/sql/UpdateStatementBuilderSpec.scala
+++ b/sqlest/src/test/scala/sqlest/sql/UpdateStatementBuilderSpec.scala
@@ -41,4 +41,23 @@ class UpdateStatementBuilderSpec extends BaseStatementBuilderSpec {
       List(List("a", "b", "c", "d", "e", "f"))
     )
   }
+
+  it should "produce the right sql for an aliased table" in {
+    val tableOneAliased = new TableOne(Some("one_alias"))
+    sql {
+      update(tableOneAliased)
+        .set(
+          tableOneAliased.col1 -> "a",
+          tableOneAliased.col2 -> "b"
+        )
+        .where(tableOneAliased.col1 === "d".column && "e".column === "f".column)
+    } should equal(
+      s"""
+         |update one as one_alias
+         |set col1 = ?, col2 = ?
+         |where ((one_alias.col1 = ?) and (? = ?))
+       """.formatSql,
+      List(List("a", "b", "d", "e", "f"))
+    )
+  }
 }


### PR DESCRIPTION
Update statement builder wasn't using the table alias in the "UPDATE <table>" syntax, but the where clauses were, leading to SQL that looked like
```
UPDATE table 
SET field1 = <new_value>
WHERE table_alias.field2 = <compare_value> 
```
This failed, obviously. It will now produce
```
UPDATE table AS table_alias
SET field1 = <new_value>
WHERE table_alias.field2 = <compare_value> 
```