### PR TITLE
Verbose exception messages should extend to errors thrown when Prepar…

### DIFF
--- a/sqlest/src/main/scala/sqlest/executor/Database.scala
+++ b/sqlest/src/main/scala/sqlest/executor/Database.scala
@@ -306,22 +306,25 @@ case class Transaction(database: Database) extends Session(database) {
     withConnection { connection =>
       val (preprocessedCommand, sql, argumentLists) = database.statementBuilder(command)
       val startTime = new DateTime
-      val preparedStatement = prepareStatement(connection, preprocessedCommand, sql, argumentLists)
+
       try {
-        val result = preparedStatement.executeBatch.sum
-        val endTime = new DateTime
-        logger.info(s"Ran sql in ${endTime.getMillis - startTime.getMillis}ms: ${logDetails(connection, sql, argumentLists)}")
-        result
+        val preparedStatement = prepareStatement(connection, preprocessedCommand, sql, argumentLists)
+        try {
+          val result = preparedStatement.executeBatch.sum
+          val endTime = new DateTime
+          logger.info(s"Ran sql in ${endTime.getMillis - startTime.getMillis}ms: ${logDetails(connection, sql, argumentLists)}")
+          result
+        } finally {
+          try {
+            if (preparedStatement != null) preparedStatement.close
+          } catch { case e: SQLException => }
+        }
       } catch {
         case NonFatal(e) =>
           if (!database.verboseExceptions)
             throw e
           else
             throw new SqlestException(s"Exception running sql: ${logDetails(connection, sql, argumentLists)}", e)
-      } finally {
-        try {
-          if (preparedStatement != null) preparedStatement.close
-        } catch { case e: SQLException => }
       }
     }
 
@@ -329,30 +332,34 @@ case class Transaction(database: Database) extends Session(database) {
     withConnection { connection =>
       val (preprocessedCommand, sql, argumentLists) = database.statementBuilder(command)
       val startTime = new DateTime
-      val preparedStatement = prepareStatement(
-        connection,
-        preprocessedCommand,
-        sql,
-        argumentLists,
-        returnKeys = true
-      )
       try {
-        val result = preparedStatement.executeUpdate
-        val rs = preparedStatement.getGeneratedKeys
-        val keys = IndexedExtractor[T](1).extractAll(ResultSetIterable(rs))
-        val endTime = new DateTime
-        logger.info(s"Ran sql in ${endTime.getMillis - startTime.getMillis}ms: ${logDetails(connection, sql, argumentLists)}")
-        keys
+        val preparedStatement = prepareStatement(
+          connection,
+          preprocessedCommand,
+          sql,
+          argumentLists,
+          returnKeys = true
+        )
+        try {
+          val result = preparedStatement.executeUpdate
+          val rs = preparedStatement.getGeneratedKeys
+          val keys = IndexedExtractor[T](1).extractAll(ResultSetIterable(rs))
+          val endTime = new DateTime
+          logger.info(s"Ran sql in ${endTime.getMillis - startTime.getMillis}ms: ${logDetails(connection, sql, argumentLists)}")
+          keys
+        } finally {
+          try {
+            if (preparedStatement != null) preparedStatement.close
+          } catch {
+            case e: SQLException =>
+          }
+        }
       } catch {
         case NonFatal(e) =>
           if (!database.verboseExceptions)
             throw e
           else
             throw new SqlestException(s"Exception running sql: ${logDetails(connection, sql, argumentLists)}", e)
-      } finally {
-        try {
-          if (preparedStatement != null) preparedStatement.close
-        } catch { case e: SQLException => }
       }
     }
 

--- a/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
+++ b/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
@@ -441,4 +441,29 @@ class ExecutorSpec extends FlatSpec with Matchers {
 
     updateException shouldBe database.anException
   }
+
+  it should "return verbose exception messages on prepare when configured to do so" in {
+    val database = TestDatabase(testResultSet, Some(keyResultSet), shouldThrow = true, verboseExceptionMessages = true, throwExceptionOnPrepare = true)
+
+    val selectException = intercept[SqlestException] {
+      database.withSession { implicit session =>
+        selectStatement.fetchAll
+      }
+    }
+
+    assert(selectException.message.startsWith("Exception running sql"))
+    selectException.cause shouldBe database.anException
+  }
+
+  it should "return the underlying exception on prepare otherwise " in {
+    val database = TestDatabase(testResultSet, Some(keyResultSet), shouldThrow = true, verboseExceptionMessages = false, throwExceptionOnPrepare = true)
+
+    val selectException = intercept[Exception] {
+      database.withSession { implicit session =>
+        selectStatement.fetchAll
+      }
+    }
+
+    selectException shouldBe database.anException
+  }
 }

--- a/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
+++ b/sqlest/src/test/scala/sqlest/executor/ExecutorSpec.scala
@@ -453,6 +453,33 @@ class ExecutorSpec extends FlatSpec with Matchers {
 
     assert(selectException.message.startsWith("Exception running sql"))
     selectException.cause shouldBe database.anException
+
+    val insertException = intercept[SqlestException] {
+      database.withTransaction { implicit transaction =>
+        insertStatement.execute
+      }
+    }
+
+    assert(insertException.message.startsWith("Exception running sql"))
+    insertException.cause shouldBe database.anException
+
+    val insertReturningKeysException = intercept[SqlestException] {
+      database.withTransaction { implicit transaction =>
+        insertStatement.executeReturningKeys[String]
+      }
+    }
+
+    assert(insertReturningKeysException.message.startsWith("Exception running sql"))
+    insertReturningKeysException.cause shouldBe database.anException
+
+    val updateException = intercept[SqlestException] {
+      database.withTransaction { implicit transaction =>
+        updateStatement.execute
+      }
+    }
+
+    assert(updateException.message.startsWith("Exception running sql"))
+    updateException.cause shouldBe database.anException
   }
 
   it should "return the underlying exception on prepare otherwise " in {
@@ -465,5 +492,29 @@ class ExecutorSpec extends FlatSpec with Matchers {
     }
 
     selectException shouldBe database.anException
+
+    val insertException = intercept[Exception] {
+      database.withTransaction { implicit transaction =>
+        insertStatement.execute
+      }
+    }
+
+    insertException shouldBe database.anException
+
+    val insertReturningKeysException = intercept[Exception] {
+      database.withTransaction { implicit transaction =>
+        insertStatement.executeReturningKeys[String]
+      }
+    }
+
+    insertReturningKeysException shouldBe database.anException
+
+    val updateException = intercept[Exception] {
+      database.withTransaction { implicit transaction =>
+        updateStatement.execute
+      }
+    }
+
+    updateException shouldBe database.anException
   }
 }

--- a/sqlest/src/test/scala/sqlest/executor/TestDatabase.scala
+++ b/sqlest/src/test/scala/sqlest/executor/TestDatabase.scala
@@ -19,7 +19,7 @@ package sqlest.executor
 import java.sql.ResultSet
 import sqlest._
 
-case class TestDatabase(resultSet: ResultSet, keyResultSet: Option[ResultSet] = None, shouldThrow: Boolean = false, verboseExceptionMessages: Boolean = false) extends Database {
+case class TestDatabase(resultSet: ResultSet, keyResultSet: Option[ResultSet] = None, shouldThrow: Boolean = false, verboseExceptionMessages: Boolean = false, throwExceptionOnPrepare: Boolean = true) extends Database {
   var preparedStatement: Option[AbstractPreparedStatement] = None
   var lastConnection: Option[AbstractConnection] = None
   override val verboseExceptions = verboseExceptionMessages
@@ -46,7 +46,8 @@ case class TestDatabase(resultSet: ResultSet, keyResultSet: Option[ResultSet] = 
         override def execute(sql: String) = if (shouldThrow) throw anException else true
       }
       override def prepareStatement(inSql: String, columnIndices: Array[Int]) = {
-        val statement = new AbstractPreparedStatement {
+
+        val statement = if (throwExceptionOnPrepare) throw anException else new AbstractPreparedStatement {
           val sql = inSql
           override def executeQuery() = if (shouldThrow) throw anException else resultSet
           override def executeUpdate() = if (shouldThrow) throw anException else 1
@@ -59,7 +60,7 @@ case class TestDatabase(resultSet: ResultSet, keyResultSet: Option[ResultSet] = 
         statement
       }
       override def prepareStatement(inSql: String, columnNames: Array[String]) = {
-        val statement = new AbstractPreparedStatement {
+        val statement = if (throwExceptionOnPrepare) throw anException else new AbstractPreparedStatement {
           val sql = inSql
           override def executeQuery() = if (shouldThrow) throw anException else resultSet
           override def executeUpdate() = if (shouldThrow) throw anException else 1
@@ -72,7 +73,7 @@ case class TestDatabase(resultSet: ResultSet, keyResultSet: Option[ResultSet] = 
         statement
       }
       override def prepareStatement(inSql: String, returnGeneratedKeys: Int) = {
-        val statement = new AbstractPreparedStatement {
+        val statement = if (throwExceptionOnPrepare) throw anException else new AbstractPreparedStatement {
           val sql = inSql
           override def executeQuery() = if (shouldThrow) throw anException else resultSet
           override def executeUpdate() = if (shouldThrow) throw anException else 1
@@ -87,7 +88,7 @@ case class TestDatabase(resultSet: ResultSet, keyResultSet: Option[ResultSet] = 
         statement
       }
       override def prepareStatement(inSql: String) = {
-        val statement = new AbstractPreparedStatement {
+        val statement = if (throwExceptionOnPrepare) throw anException else new AbstractPreparedStatement {
           val sql = inSql
           override def executeQuery() = if (shouldThrow) throw anException else resultSet
           override def executeUpdate() = if (shouldThrow) throw anException else 1

--- a/sqlest/src/test/scala/sqlest/executor/TestDatabase.scala
+++ b/sqlest/src/test/scala/sqlest/executor/TestDatabase.scala
@@ -19,7 +19,7 @@ package sqlest.executor
 import java.sql.ResultSet
 import sqlest._
 
-case class TestDatabase(resultSet: ResultSet, keyResultSet: Option[ResultSet] = None, shouldThrow: Boolean = false, verboseExceptionMessages: Boolean = false, throwExceptionOnPrepare: Boolean = true) extends Database {
+case class TestDatabase(resultSet: ResultSet, keyResultSet: Option[ResultSet] = None, shouldThrow: Boolean = false, verboseExceptionMessages: Boolean = false, throwExceptionOnPrepare: Boolean = false) extends Database {
   var preparedStatement: Option[AbstractPreparedStatement] = None
   var lastConnection: Option[AbstractConnection] = None
   override val verboseExceptions = verboseExceptionMessages


### PR DESCRIPTION
…ing a statement, as well as ones when executing it as many common SQL errors (like selecting a column from a table not in the from or joins clauses) will show up.